### PR TITLE
docs: Add userguide for building & packaging

### DIFF
--- a/containers/dependencies_golang.go
+++ b/containers/dependencies_golang.go
@@ -10,8 +10,9 @@ func WithCachedGoDependencies(container *dagger.Container, dir *dagger.Directory
 
 func DownloadGolangDependencies(d *dagger.Client, gomod, gosum *dagger.File) *dagger.Directory {
 	container := GolangContainer(d, "", GoImage).
-		WithMountedFile("go.mod", gomod).
-		WithMountedFile("go.sum", gosum).
+		WithWorkdir("/src").
+		WithMountedFile("/src/go.mod", gomod).
+		WithMountedFile("/src/go.sum", gosum).
 		WithExec([]string{"go", "mod", "download"})
 
 	return container.Directory("/go/pkg/mod")

--- a/docs/guides/building.md
+++ b/docs/guides/building.md
@@ -1,0 +1,14 @@
+# Build & Packaging Grafana
+
+The main goal of grafana-build is (as the name already indicates) building Grafana for various platforms. 
+This actually consists of various parts as you need to have a binary of Grafana and the JavaScript/CSS frontend before you can then package everything up.
+
+All of that is encompassed by the `package` command:
+
+```
+$ go run ./cmd --enterprise package --distro darwin/amd64
+```
+
+The command above will build the backend binary for macOS on Apple Silicon and package that up into a single archive with the frontend artefacts: `grafana-enterprise-darwin-arm64.tar.gz`
+
+If you then extract that package and run `./bin/grafana-server`, Grafana will launch and you will be able to access it via <http://localhost:3000>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
 # Welcome to Grafana Build
 
-This repository should make it as easy as possible to build a Grafana binary for various platforms.
+Grafana Build is a build pipeline for Grafana using Dagger.
+The goal of this project is to make it as easy as possible to generate builds as part of the overall release pipeline.

--- a/docs/meta/docs.md
+++ b/docs/meta/docs.md
@@ -1,0 +1,10 @@
+# Documentation
+
+The documentation for this project is written using Mkdocs.
+To get a local preview of it (e.g. if you want to test-run some changes), run the following command:
+
+```
+$ go run ./ci docs serve
+```
+
+You can then browse the rendered documentation on <http://localhost:8000>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,10 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
 nav:
   - index.md
+  - "Guides":
+    - guides/building.md
+  - "Meta":
+    - meta/docs.md
 repo_url: https://github.com/grafana/grafana-build
 site_name: Grafana Build
 theme:


### PR DESCRIPTION
This also includes a small code-change I had to make to get the `go mod download` call running.