### PR TITLE
Add package publish action

### DIFF
--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -14,7 +14,7 @@ inputs:
     descrpition: 'The version string to assign to the packages'
     required: false
   destination:
-    description: 'The GCS bucket path to upload the 'grafana.tar.gz's to. This destination should be a folder'
+    description: 'The GCS bucket path to upload the "grafana.tar.gz" packages to. This destination should be a folder'
     required: false
   github_token:
     description: 'The token used to clone Grafana and Grafana Enterprise'

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
   distros:
     description: 'A list of distributions to create packages for'
-    default: ['linux/amd64', 'linux/arm64']
+    default: 'linux/amd64,linux/arm64'
     required: true
 runs:
   using: composite
@@ -39,5 +39,5 @@ runs:
         --enterprise-ref=${{ inputs.enterprise_ref }} \
         --destination=${{ inputs.destination }} \
         --github-token=${{ inputs.github_token }} \
-        --distro=${{ join(inputs.distros, ",") }} \
+        --distro=${{ inputs.distros }} \
         --gcp-service-account-key=/var/gcp-service-account-key.json

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -16,9 +16,6 @@ inputs:
   destination:
     description: 'The GCS bucket path to upload the "grafana.tar.gz" packages to. This destination should be a folder'
     required: false
-  github_token:
-    description: 'The token used to clone Grafana and Grafana Enterprise'
-    required: false
   gcp_service_account_key_base64:
     description: 'The service account key used to upload the artifacts to Google Cloud Storage, encoded in base64'
     required: false
@@ -35,7 +32,7 @@ runs:
         --enterprise=${{ inputs.enterprise }} \
         --enterprise-ref=${{ inputs.enterprise_ref }} \
         --grafana-ref=${{ inputs.grafana_ref }} \
-        --github-token=${{ inputs.github_token }} \
+        --github-token=${{ secrets.GITHUB_TOKEN }} \
       package \
         --distro=${{ inputs.distros }} \
       publish \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
   - shell: bash
     run: |
-      go run ./cmd 
+      go run ./cmd \
         --enterprise=${{ inputs.enterprise }} \
         --enterprise-ref=${{ inputs.enterprise_ref }} \
         --grafana-ref=${{ inputs.grafana_ref }} \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
   - shell: bash
-    run: echo ${{ inputs.gcp_service_account_key }} > /var/gcp-service-account-key.json
+    run: echo ${{ inputs.gcp_service_account_key }} > /gcp-service-account-key.json
   - shell: bash
     run: |
       go run ./cmd package publish \
@@ -40,4 +40,4 @@ runs:
         --destination=${{ inputs.destination }} \
         --github-token=${{ inputs.github_token }} \
         --distro=${{ inputs.distros }} \
-        --gcp-service-account-key=/var/gcp-service-account-key.json
+        --gcp-service-account-key=/gcp-service-account-key.json

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -1,0 +1,43 @@
+name: Package Grafana Backend
+inputs:
+  grafana_ref:
+    description: 'The commit to use when checking out Grafana'
+    required: true
+    default: 'main'
+  enterprise:
+    description: 'Whether or not to use Grafana Enterprise. Supplying this argument means that you have a GitHub token that is capable of cloning Grafana Enterprise'
+    required: false
+  enterprise_ref:
+    description: 'The commit to use when checking out Grafana Enterprise'
+    required: false
+  version:
+    descrpition: 'The version string to assign to the packages'
+    required: false
+  destination:
+    description: 'The GCS bucket path to upload the 'grafana.tar.gz's to. This destination should be a folder'
+    required: false
+  github_token:
+    description: 'The token used to clone Grafana and Grafana Enterprise'
+    required: false
+  gcp_service_account_key:
+    description: 'The service account key used to upload the artifacts to Google Cloud Storage'
+    required: false
+  distros:
+    description: 'A list of distributions to create packages for'
+    default: ['linux/amd64', 'linux/arm64']
+    required: true
+runs:
+  using: composite
+  steps:
+  - shell: bash
+    run: echo ${{ inputs.gcp_service_account_key }} > /var/gcp-service-account-key.json
+  - shell: bash
+    run: |
+      go run ./cmd package publish \
+        --grafana-ref=${{ inputs.grafana_ref }} \
+        --enterprise=${{ inputs.enterprise }} \
+        --enterprise-ref=${{ inputs.enterprise_ref }} \
+        --destination=${{ inputs.destination }} \
+        --github-token=${{ inputs.github_token }} \
+        --distro=${{ join(inputs.distros, ",") }} \
+        --gcp-service-account-key=/var/gcp-service-account-key.json

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: 'A list of distributions to create packages for'
     default: 'linux/amd64,linux/arm64'
     required: true
+  build_id:
+    description: 'The build number, which is appended to the package name (before .tar.gz)'
+    required: true
 runs:
   using: composite
   steps:
@@ -35,6 +38,7 @@ runs:
         --enterprise=${{ inputs.enterprise }} \
         --enterprise-ref="${{ inputs.enterprise_ref }}" \
         --grafana-ref="${{ inputs.grafana_ref }}" \
+        --build-id="${{ inputs.build_id }}" \
       package \
         --distro=${{ inputs.distros }} \
       publish \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -33,8 +33,8 @@ runs:
     run: |
       go run ./cmd \
         --enterprise=${{ inputs.enterprise }} \
-        --enterprise-ref=${{ inputs.enterprise_ref }} \
-        --grafana-ref=${{ inputs.grafana_ref }} \
+        --enterprise-ref="${{ inputs.enterprise_ref }}" \
+        --grafana-ref="${{ inputs.grafana_ref }}" \
       package \
         --distro=${{ inputs.distros }} \
       publish \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -16,6 +16,9 @@ inputs:
   destination:
     description: 'The GCS bucket path to upload the "grafana.tar.gz" packages to. This destination should be a folder'
     required: false
+  github_token:
+    description: 'The token used to clone Grafana and Grafana Enterprise'
+    required: false
   gcp_service_account_key_base64:
     description: 'The service account key used to upload the artifacts to Google Cloud Storage, encoded in base64'
     required: false
@@ -32,7 +35,6 @@ runs:
         --enterprise=${{ inputs.enterprise }} \
         --enterprise-ref=${{ inputs.enterprise_ref }} \
         --grafana-ref=${{ inputs.grafana_ref }} \
-        --github-token=${{ secrets.GITHUB_TOKEN }} \
       package \
         --distro=${{ inputs.distros }} \
       publish \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -31,11 +31,13 @@ runs:
   steps:
   - shell: bash
     run: |
-      go run ./cmd package publish \
-        --grafana-ref=${{ inputs.grafana_ref }} \
+      go run ./cmd 
         --enterprise=${{ inputs.enterprise }} \
         --enterprise-ref=${{ inputs.enterprise_ref }} \
-        --destination=${{ inputs.destination }} \
+        --grafana-ref=${{ inputs.grafana_ref }} \
         --github-token=${{ inputs.github_token }} \
+      package \
         --distro=${{ inputs.distros }} \
+      publish \
+        --destination=${{ inputs.destination }} \
         --gcp-service-account-key-base64=${{ inputs.gcp_service_account_key_base64 }}

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -30,8 +30,6 @@ runs:
   using: composite
   steps:
   - shell: bash
-    run: echo ${{ inputs.gcp_service_account_key }} > /gcp-service-account-key.json
-  - shell: bash
     run: |
       go run ./cmd package publish \
         --grafana-ref=${{ inputs.grafana_ref }} \

--- a/actions/package/publish/action.yml
+++ b/actions/package/publish/action.yml
@@ -19,8 +19,8 @@ inputs:
   github_token:
     description: 'The token used to clone Grafana and Grafana Enterprise'
     required: false
-  gcp_service_account_key:
-    description: 'The service account key used to upload the artifacts to Google Cloud Storage'
+  gcp_service_account_key_base64:
+    description: 'The service account key used to upload the artifacts to Google Cloud Storage, encoded in base64'
     required: false
   distros:
     description: 'A list of distributions to create packages for'
@@ -40,4 +40,4 @@ runs:
         --destination=${{ inputs.destination }} \
         --github-token=${{ inputs.github_token }} \
         --distro=${{ inputs.distros }} \
-        --gcp-service-account-key=/gcp-service-account-key.json
+        --gcp-service-account-key-base64=${{ inputs.gcp_service_account_key_base64 }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,19 +5,13 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
-	"math/rand"
 	"os"
-	"time"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/containers"
 	"github.com/grafana/grafana-build/pipelines"
 	"github.com/urfave/cli/v2"
 )
-
-func init() {
-	rand.Seed(time.Now().Unix())
-}
 
 var app = &cli.App{
 	Flags: []cli.Flag{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"math/rand"
 	"os"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/containers"
 	"github.com/grafana/grafana-build/pipelines"
 	"github.com/urfave/cli/v2"
 )
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
 
 var app = &cli.App{
 	Flags: []cli.Flag{
@@ -36,6 +42,10 @@ var app = &cli.App{
 		},
 		&cli.StringFlag{
 			Name:     "github-token",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "build-id",
 			Required: false,
 		},
 	},
@@ -66,7 +76,12 @@ func PipelineArgsFromContext(c *cli.Context, client *dagger.Client) (pipelines.P
 		ref           = c.String("grafana-ref")
 		enterprise    = c.Bool("enterprise")
 		enterpriseRef = c.String("enterprise-ref")
+		buildID       = c.String("build-id")
 	)
+
+	if buildID == "" {
+		buildID = randomString(12)
+	}
 
 	path := c.Args().Get(0)
 	if path == "" {
@@ -84,6 +99,7 @@ func PipelineArgsFromContext(c *cli.Context, client *dagger.Client) (pipelines.P
 		}
 
 		return pipelines.PipelineArgs{
+			BuildID:       buildID,
 			Verbose:       verbose,
 			Version:       version,
 			Ref:           ref,
@@ -115,6 +131,7 @@ func PipelineArgsFromContext(c *cli.Context, client *dagger.Client) (pipelines.P
 	}
 
 	return pipelines.PipelineArgs{
+		BuildID:    buildID,
 		Verbose:    verbose,
 		Version:    version,
 		Enterprise: enterprise,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,6 +77,7 @@ func PipelineArgsFromContext(c *cli.Context, client *dagger.Client) (pipelines.P
 		enterprise    = c.Bool("enterprise")
 		enterpriseRef = c.String("enterprise-ref")
 		buildID       = c.String("build-id")
+		src           *dagger.Directory
 	)
 
 	if buildID == "" {
@@ -91,43 +92,49 @@ func PipelineArgsFromContext(c *cli.Context, client *dagger.Client) (pipelines.P
 	f, err := os.Stat(path)
 	// It's okay if the folder doesn't exist; if it doesn't, we'll just clone the repo.
 	// Other errors though it's worth just returning on.
-	if err == nil {
-		// If it does exist but it's not a directory then we should throw an error.
-		// If it doesn't exist, then this block will be skipped and the project will be cloned.
-		if !f.IsDir() {
-			return pipelines.PipelineArgs{}, errors.New("path provided is not a directory")
+	if err != nil {
+		// If there was some error other than the directory not existing, then we likely need to return that.
+		if !errors.Is(err, fs.ErrNotExist) {
+			return pipelines.PipelineArgs{}, err
 		}
 
-		return pipelines.PipelineArgs{
-			BuildID:       buildID,
-			Verbose:       verbose,
-			Version:       version,
-			Ref:           ref,
-			EnterpriseRef: enterpriseRef,
-			Enterprise:    enterprise,
-			Context:       c,
-			Grafana:       client.Host().Directory(path),
-		}, nil
-	}
-
-	if !errors.Is(err, fs.ErrNotExist) {
-		return pipelines.PipelineArgs{}, err
-	}
-
-	// If the folder doesn't exist, then we want to clone Grafana.
-	src, err := containers.Clone(client, "https://github.com/grafana/grafana.git", ref)
-	if err != nil {
-		return pipelines.PipelineArgs{}, err
-	}
-
-	// If the 'enterprise global flag is set, then clone and initialize Grafana Enterprise as well.
-	if enterprise {
-		enterpriseDir, err := containers.CloneWithGitHubToken(client, c.String("github-token"), "https://github.com/grafana/grafana-enterprise.git", enterpriseRef)
+		// If the folder doesn't exist, then we want to clone Grafana.
+		srcDir, err := containers.Clone(client, "https://github.com/grafana/grafana.git", ref)
 		if err != nil {
 			return pipelines.PipelineArgs{}, err
 		}
 
-		src = containers.InitializeEnterprise(client, src, enterpriseDir)
+		// If the 'enterprise global flag is set, then clone and initialize Grafana Enterprise as well.
+		if enterprise {
+			enterpriseDir, err := containers.CloneWithGitHubToken(client, c.String("github-token"), "https://github.com/grafana/grafana-enterprise.git", enterpriseRef)
+			if err != nil {
+				return pipelines.PipelineArgs{}, err
+			}
+
+			srcDir = containers.InitializeEnterprise(client, srcDir, enterpriseDir)
+		}
+
+		// Set the source directory to the result of the git clone.
+		src = srcDir
+	} else {
+		// If it does exist but it's not a directory then we should throw an error.
+		if !f.IsDir() {
+			return pipelines.PipelineArgs{}, errors.New("path provided is not a directory")
+		}
+
+		// Set the source directory to be the path provided.
+		src = client.Host().Directory(path)
+	}
+
+	if version == "" {
+		log.Println("Version not provided; getting version from package.json...")
+		v, err := containers.GetPackageJSONVersion(c.Context, client, src)
+		if err != nil {
+			return pipelines.PipelineArgs{}, err
+		}
+
+		version = v
+		log.Println("Got version", v)
 	}
 
 	return pipelines.PipelineArgs{

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -24,6 +24,11 @@ var PackageCommand = &cli.Command{
 					Required: true,
 				},
 				&cli.StringFlag{
+					Name:     "gcp-service-account-key-base64",
+					Usage:    "Provides a service-account key encoded in base64 to use to authenticate with the Google Cloud SDK",
+					Required: false,
+				},
+				&cli.StringFlag{
 					Name:     "gcp-service-account-key",
 					Usage:    "Provides a service-account keyfile to use to authenticate with the Google Cloud SDK. If not provided or is empty, then $XDG_CONFIG_HOME/gcloud will be mounted in the container",
 					Required: false,

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -19,12 +19,12 @@ var PackageCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     "destination",
-					Usage:    "GCS URL to upload the package (example: gs://bucket/grafana.tar.gz)",
+					Usage:    "GCS URL to upload the packages to (example: gs://bucket/grafana/)",
 					Aliases:  []string{"d"},
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:     "key",
+					Name:     "gcp-service-account-key",
 					Usage:    "Provides a service-account keyfile to use to authenticate with the Google Cloud SDK. If not provided or is empty, then $XDG_CONFIG_HOME/gcloud will be mounted in the container",
 					Required: false,
 				},

--- a/cmd/random_string.go
+++ b/cmd/random_string.go
@@ -1,0 +1,13 @@
+package main
+
+import "math/rand"
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randomString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/cmd/random_string.go
+++ b/cmd/random_string.go
@@ -1,13 +1,17 @@
 package main
 
-import "math/rand"
+import (
+	"math/rand"
+	"time"
+)
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func randomString(n int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
 }

--- a/containers/build_backend_platforms.go
+++ b/containers/build_backend_platforms.go
@@ -122,4 +122,6 @@ var DistributionGoOpts = map[executil.Distribution]DistroBuildOptsFunc{
 
 	executil.DistWindowsAMD64: BuildOptsDynamicWindows,
 	executil.DistWindowsARM64: BuildOptsDynamicWindows,
+
+	executil.DistPlan9AMD64: BuildOptsDynamic,
 }

--- a/containers/buildinfo.go
+++ b/containers/buildinfo.go
@@ -57,7 +57,7 @@ func GetBuildInfo(ctx context.Context, d *dagger.Client, dir *dagger.Directory, 
 func revParseShort(ctx context.Context, container *dagger.Container) (string, error) {
 	c := container.WithExec([]string{"rev-parse", "--short", "HEAD"})
 
-	if err := ExitError(ctx, container); err != nil {
+	if err := ExitError(ctx, c); err != nil {
 		return "", err
 	}
 
@@ -72,7 +72,7 @@ func revParseShort(ctx context.Context, container *dagger.Container) (string, er
 func revParseBranch(ctx context.Context, container *dagger.Container) (string, error) {
 	c := container.WithExec([]string{"rev-parse", "--abbrev-ref", "HEAD"})
 
-	if err := ExitError(ctx, container); err != nil {
+	if err := ExitError(ctx, c); err != nil {
 		return "", err
 	}
 

--- a/containers/clone.go
+++ b/containers/clone.go
@@ -27,6 +27,10 @@ type GitCloneOptions struct {
 }
 
 // CloneContainer returns the container definition that uses git clone to clone the 'git url' and checks out the ref provided at 'ref'.
+// Multiple refs can be provided via a space character (' '). If multiple refs are provided, then the container will attempt to checkout
+// each ref at a time, stopping at the first one that is successful.
+// This can be useful in PRs which have a coupled association with another codebase.
+// A practical example (and why this exists): "${pr_source_branch} ${pr_target_branch} ${main}" will first attempt to checkout the PR source branch, then the PR target branch, then "main"; whichever is successul first.
 func CloneContainer(d *dagger.Client, opts *GitCloneOptions) (*dagger.Container, error) {
 	var err error
 	if opts.URL == "" {
@@ -45,12 +49,7 @@ func CloneContainer(d *dagger.Client, opts *GitCloneOptions) (*dagger.Container,
 		}
 	}
 
-	ref := "main"
-	if opts.Ref != "" {
-		ref = opts.Ref
-	}
-
-	cloneArgs := []string{"git", "clone", "--branch", ref}
+	cloneArgs := []string{"git", "clone"}
 	if opts.Depth != 0 {
 		cloneArgs = append(cloneArgs, "--depth", strconv.Itoa(opts.Depth))
 	}
@@ -81,15 +80,40 @@ func CloneContainer(d *dagger.Client, opts *GitCloneOptions) (*dagger.Container,
 		WithSecretVariable("GIT_CLONE_URL", cloneURLSecret).
 		WithExec([]string{"/bin/sh", "-c", strings.Join(cloneArgs, " ")})
 
+	ref := "main"
+	if opts.Ref != "" {
+		ref = opts.Ref
+	}
+
+	// TODO: this section really needs to be its own function with unit tests, or an interface or something.
+	var (
+		checkouts    = strings.Split(ref, " ")
+		checkoutArgs = []string{fmt.Sprintf(`if git -C src checkout %[1]s; then echo "checked out %[1]s";`, checkouts[0])}
+	)
+
+	if len(checkouts) > 1 {
+		// In cases where there's only 2 elements in the list this value will be empty.
+		middle := checkouts[1 : len(checkouts)-1]
+		for _, v := range middle {
+			checkoutArgs = append(checkoutArgs, fmt.Sprintf(`elif git -C src checkout %[1]s; then echo "checked out %[1]s";`, v))
+		}
+
+		last := checkouts[len(checkouts)-1]
+		checkoutArgs = append(checkoutArgs, fmt.Sprintf(`else git -C src checkout %s;`, last))
+	}
+
+	checkoutArgs = append(checkoutArgs, "fi")
+
+	container = container.WithExec([]string{"/bin/sh", "-c", strings.Join(checkoutArgs, " ")})
 	return container, nil
 }
 
 // Clone returns the directory with the cloned repository ('url') and checked out ref ('ref').
 func Clone(d *dagger.Client, url, ref string) (*dagger.Directory, error) {
 	container, err := CloneContainer(d, &GitCloneOptions{
-		URL:   url,
-		Ref:   ref,
-		Depth: 1,
+		URL: url,
+		Ref: ref,
+		//Depth: 1,
 	})
 
 	if err != nil {

--- a/containers/google_cloud.go
+++ b/containers/google_cloud.go
@@ -72,7 +72,10 @@ func GCSUploadDirectory(d *dagger.Client, image string, auth GCPAuthenticator, d
 		return nil, err
 	}
 
-	return container.WithExec([]string{"gsutil", "-m", "rsync", "-r", "/src", dst}), nil
+	secret := d.SetSecret("gcs-destination", dst)
+	container = container.WithSecretVariable("GCS_DESTINATION", secret)
+
+	return container.WithExec([]string{"/bin/sh", "-c", "gsutil -m rsync -r /src ${GCS_DESTINATION}"}), nil
 }
 
 func GCSUploadFile(d *dagger.Client, image string, auth GCPAuthenticator, file *dagger.File, dst string) (*dagger.Container, error) {
@@ -84,6 +87,7 @@ func GCSUploadFile(d *dagger.Client, image string, auth GCPAuthenticator, file *
 	if err != nil {
 		return nil, err
 	}
-
-	return container.WithExec([]string{"gsutil", "cp", "/src/file", dst}), nil
+	secret := d.SetSecret("gcs-destination", dst)
+	container = container.WithSecretVariable("GCS_DESTINATION", secret)
+	return container.WithExec([]string{"/bin/sh", "-c", "gsutil cp /src/file ${GCS_DESTINATION}"}), nil
 }

--- a/containers/version.go
+++ b/containers/version.go
@@ -1,0 +1,23 @@
+package containers
+
+import (
+	"context"
+	"strings"
+
+	"dagger.io/dagger"
+)
+
+// GetPackageJSONVersion gets the "version" field from package.json in the 'src' directory.
+func GetPackageJSONVersion(ctx context.Context, d *dagger.Client, src *dagger.Directory) (string, error) {
+	c := d.Container().From("alpine").
+		WithExec([]string{"apk", "--update", "add", "jq"}).
+		WithMountedDirectory("/src", src).
+		WithWorkdir("/src").
+		WithExec([]string{"/bin/sh", "-c", "cat package.json | jq -r .version"})
+
+	if stdout, err := c.Stdout(ctx); err == nil {
+		return strings.TrimSpace(stdout), nil
+	}
+
+	return c.Stderr(ctx)
+}

--- a/executil/go_build.go
+++ b/executil/go_build.go
@@ -220,7 +220,7 @@ func OSAndArch(d Distribution) (string, string) {
 
 func ArchVersion(d Distribution) string {
 	p := strings.Split(string(d), "/")
-	if len(p) > 3 {
+	if len(p) < 3 {
 		return ""
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana-build
 go 1.20
 
 require (
-	dagger.io/dagger v0.4.6
+	dagger.io/dagger v0.5.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.24.4
@@ -19,7 +19,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dagger.io/dagger v0.4.6 h1:1GpHJuGrDcLCCIprLpwTXBpKg8Te/RVIDo1qpzkL/QE=
 dagger.io/dagger v0.4.6/go.mod h1:1nbGnLdIfoBV2ahbQjheI//SNGz+b5q1jqf0A+pJ+Oc=
+dagger.io/dagger v0.5.2 h1:xNMUnLWqcsb5UrvqOgJx4MJVfe7xDb50kBMXdC63Cjs=
+dagger.io/dagger v0.5.2/go.mod h1:1nbGnLdIfoBV2ahbQjheI//SNGz+b5q1jqf0A+pJ+Oc=
 github.com/99designs/gqlgen v0.17.2/go.mod h1:K5fzLKwtph+FFgh9j7nFbRUdBKvTcGnsta51fsMTn3o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Khan/genqlient v0.5.0 h1:TMZJ+tl/BpbmGyIBiXzKzUftDhw4ZWxQZ+1ydn0gyII=
@@ -90,6 +92,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -103,6 +107,8 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pipelines/backend_build.go
+++ b/pipelines/backend_build.go
@@ -54,7 +54,7 @@ func GrafanaBackendBuildDirectories(ctx context.Context, d *dagger.Client, src *
 // GrafanaBackendBuild builds all of the distributions in the '--distros' argument and places them in the 'bin' directory of the PWD.
 func GrafanaBackendBuild(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 	var (
-		version    = args.Context.String("version")
+		version    = args.Version
 		distroList = args.Context.StringSlice("distro")
 		distros    = make([]executil.Distribution, len(distroList))
 	)

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -24,16 +24,25 @@ var PackagedPaths = []string{
 	"docs/sources/",
 }
 
+// TarFileName returns a file name that matches this format: {grafana|grafana-enterprise}_{version}_{os}_{arch}_{build_number}.tar.gz
 func TarFilename(args PipelineArgs, distro executil.Distribution) string {
 	name := "grafana"
 	if args.Enterprise {
 		name = "grafana-enterprise"
 	}
+	var (
+		// This should return something like "linux", "arm"
+		os, arch = executil.OSAndArch(distro)
+		// If applicable this will be set to something like "7" (for arm7)
+		archv = executil.ArchVersion(distro)
+	)
+	if archv != "" {
+		arch = strings.Join([]string{arch, archv}, "-")
+	}
 
-	suffix := string(distro)
-	suffix = strings.ReplaceAll(suffix, "/", "-")
+	p := []string{name, args.Version, os, arch, args.BuildID}
 
-	return fmt.Sprintf("%s-%s.tar.gz", name, suffix)
+	return fmt.Sprintf("%s.tar.gz", strings.Join(p, "_"))
 }
 
 // PackageFile builds and packages Grafana into a tar.gz for each dsitrbution and returns a map of the dagger file that holds each tarball, keyed by the distribution it corresponds to.

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -53,6 +53,14 @@ func PackageFiles(ctx context.Context, d *dagger.Client, args PipelineArgs) (map
 		distros = executil.DistrosFromStringSlice(args.Context.StringSlice("distro"))
 	)
 
+	if version == "" {
+		v, err := containers.GetPackageJSONVersion(ctx, d, src)
+		if err != nil {
+			return nil, err
+		}
+		version = v
+	}
+
 	backends, err := GrafanaBackendBuildDirectories(ctx, d, src, distros, version)
 	if err != nil {
 		return nil, err

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -40,7 +40,7 @@ func TarFilename(args PipelineArgs, distro executil.Distribution) string {
 func PackageFiles(ctx context.Context, d *dagger.Client, args PipelineArgs) (map[executil.Distribution]*dagger.File, error) {
 	var (
 		src     = args.Grafana
-		version = args.Context.String("version")
+		version = strings.TrimPrefix(args.Context.String("version"), "v")
 		distros = executil.DistrosFromStringSlice(args.Context.StringSlice("distro"))
 	)
 

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -49,17 +49,9 @@ func TarFilename(args PipelineArgs, distro executil.Distribution) string {
 func PackageFiles(ctx context.Context, d *dagger.Client, args PipelineArgs) (map[executil.Distribution]*dagger.File, error) {
 	var (
 		src     = args.Grafana
-		version = strings.TrimPrefix(args.Context.String("version"), "v")
+		version = args.Version
 		distros = executil.DistrosFromStringSlice(args.Context.StringSlice("distro"))
 	)
-
-	if version == "" {
-		v, err := containers.GetPackageJSONVersion(ctx, d, src)
-		if err != nil {
-			return nil, err
-		}
-		version = v
-	}
 
 	backends, err := GrafanaBackendBuildDirectories(ctx, d, src, distros, version)
 	if err != nil {

--- a/pipelines/package_publish.go
+++ b/pipelines/package_publish.go
@@ -1,0 +1,53 @@
+package pipelines
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/grafana/grafana-build/containers"
+)
+
+// PublishPackage creates a package and publishes it to a Google Cloud Storage bucket.
+func PublishPackage(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
+	packages, err := PackageFiles(ctx, d, args)
+	if err != nil {
+		return err
+	}
+
+	var auth containers.GCPAuthenticator = &containers.GCPInheritedAuth{}
+	// The order of operations:
+	// 1. Try to use base64 key.
+	// 2. Try to use gcp-service-account-key (path to a file).
+	// 3. Try mounting $XDG_CONFIG_HOME/gcloud
+	if key := args.Context.String("gcp-service-account-key-base64"); key != "" {
+		log.Println("Handling GCP authentication using Service account key from base64...")
+		secret := d.SetSecret("gcp-sa-key-base64", key)
+		// Write key to a file in an alpine container...
+		file := d.Container().From("alpine").
+			WithSecretVariable("GCP_SERVICE_ACCOUNT_KEY_BASE64", secret).
+			WithExec([]string{"/bin/sh", "-c", "echo $GCP_SERVICE_ACCOUNT_KEY_BASE64 | base64 -d > /key.json"}).
+			File("/key.json")
+
+		auth = containers.NewGCPServiceAccountWithFile(file)
+	} else if key := args.Context.String("gcp-service-account-key"); key != "" {
+		log.Println("Handling GCP authentication using Service account key from file...")
+		auth = containers.NewGCPServiceAccount(key)
+	}
+
+	for distro, targz := range packages {
+		dst := strings.Join([]string{args.Context.Path("destination"), TarFilename(args, distro)}, "/")
+		log.Println("Writing package", TarFilename(args, distro), "to", dst)
+		uploader, err := containers.GCSUploadFile(d, containers.GoogleCloudImage, auth, targz, dst)
+		if err != nil {
+			return err
+		}
+
+		if err := containers.ExitError(ctx, uploader); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pipelines/package_test.go
+++ b/pipelines/package_test.go
@@ -1,0 +1,50 @@
+package pipelines_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-build/executil"
+	"github.com/grafana/grafana-build/pipelines"
+)
+
+func TestTarFilename(t *testing.T) {
+	t.Run("It should use the correct name if Enterprise is false", func(t *testing.T) {
+		distro := executil.Distribution("plan9/amd64")
+		args := pipelines.PipelineArgs{
+			Version:    "v1.0.1-test",
+			BuildID:    "333",
+			Enterprise: false,
+		}
+
+		expected := "grafana_v1.0.1-test_plan9_amd64_333.tar.gz"
+		if name := pipelines.TarFilename(args, distro); name != expected {
+			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
+		}
+	})
+	t.Run("It should use the correct name if Enterprise is true", func(t *testing.T) {
+		distro := executil.Distribution("plan9/amd64")
+		args := pipelines.PipelineArgs{
+			Version:    "v1.0.1-test",
+			BuildID:    "333",
+			Enterprise: true,
+		}
+
+		expected := "grafana-enterprise_v1.0.1-test_plan9_amd64_333.tar.gz"
+		if name := pipelines.TarFilename(args, distro); name != expected {
+			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
+		}
+	})
+	t.Run("It should use include the arch version if one is supplied in the distro", func(t *testing.T) {
+		distro := executil.Distribution("plan9/arm/v6")
+		args := pipelines.PipelineArgs{
+			Version:    "v1.0.1-test",
+			BuildID:    "333",
+			Enterprise: true,
+		}
+
+		expected := "grafana-enterprise_v1.0.1-test_plan9_arm-6_333.tar.gz"
+		if name := pipelines.TarFilename(args, distro); name != expected {
+			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
+		}
+	})
+}

--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -16,6 +16,7 @@ type PipelineArgs struct {
 	Enterprise    bool
 	EnterpriseRef string
 	Version       string
+	BuildID       string
 
 	// Context is available for all sub-commands that define their own flags.
 	Context *cli.Context

--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -10,10 +10,12 @@ import (
 
 type PipelineArgs struct {
 	// These arguments are ones that are available at the global level.
-	Grafana    *dagger.Directory
-	Verbose    bool
-	Enterprise bool
-	Version    string
+	Grafana       *dagger.Directory
+	Verbose       bool
+	Ref           string
+	Enterprise    bool
+	EnterpriseRef string
+	Version       string
 
 	// Context is available for all sub-commands that define their own flags.
 	Context *cli.Context


### PR DESCRIPTION
This is a big PR since I was just sprinting a bit to get this to actually work in a GitHub action in Grafana. I would have split this up into smaller ones normally but I'm getting tired.

This resolves many issues:

* Resolves #26 - We're creating grafana tarballs in the right name format.
* Resolves #25 - the `--gcp-service-account-key-base64` argument has been added.
* Resolves #22 - `version` is no longer being used as the Grafana / Enterprise git ref to check out; a separate `--grafana-ref` and `--enterprise-ref` have been added.
* Resolves #23 - see above
* Resolves #24 - GCP and git related secrets were moved to a Dagger secret where they will be scrubbed from `stdout`.

Some other fixes:

* In an effort to avoid situations where we specify a version from a tag, but package.json says something different, we allow for the caller to provide a `--version` argument which will take precedence over checking package.json.
* Updated the dagger module so we could use secrets & services.

Here's an example CI run that built, packaged, and uploaded Grafana: https://github.com/grafana/grafana/actions/runs/4576135050/jobs/8082598330