### PR TITLE
Remove buildkit platform emulation which is just too slow for us

### DIFF
--- a/cmd/default_distros_darwin.go
+++ b/cmd/default_distros_darwin.go
@@ -1,5 +1,0 @@
-//go:build darwin
-
-package main
-
-var DefaultDistros = []string{"darwin/amd64", "darwin/arm64"}

--- a/cmd/default_distros_windows.go
+++ b/cmd/default_distros_windows.go
@@ -1,5 +1,0 @@
-//go:build windows
-
-package main
-
-var DefaultDistros = []string{"windows/amd64", "windows/arm64"}

--- a/cmd/default_dsitros_linux.go
+++ b/cmd/default_dsitros_linux.go
@@ -1,5 +1,0 @@
-//go:build linux
-
-package main
-
-var DefaultDistros = []string{"linux/amd64", "linux/arm/v6", "linux/arm64"}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -90,7 +90,7 @@ var GrafanaFlags = []cli.Flag{
 var FlagDistros = &cli.StringSliceFlag{
 	Name:  "distro",
 	Usage: "See the list of distributions with 'go tool dist list'. For variations of the same distribution, like 'armv6' or 'armv7', append an extra path part. Example: 'linux/arm/v6', or 'linux/amd64/v3'.",
-	Value: cli.NewStringSlice(DefaultDistros...),
+	Value: cli.NewStringSlice("linux/amd64", "linux/arm64"),
 }
 
 // PackageFlags are flags that are used when building packages or similar artifacts (like binaries) for different distributions

--- a/containers/base_golang.go
+++ b/containers/base_golang.go
@@ -7,11 +7,8 @@ import (
 )
 
 // GolangContainer returns a dagger container with everything set up that is needed to build Grafana's Go backend or run the Golang tests.
-func GolangContainer(d *dagger.Client, platform dagger.Platform, base string) *dagger.Container {
+func GolangContainer(d *dagger.Client, base string) *dagger.Container {
 	opts := dagger.ContainerOpts{}
-	if platform != "" {
-		opts.Platform = platform
-	}
 
 	container := d.Container(opts).From(base)
 

--- a/containers/base_grafana.go
+++ b/containers/base_grafana.go
@@ -10,8 +10,8 @@ import (
 // * 'make' is installed.
 // * the wire dependency graph has been generated (using 'make gen-go')
 // * schemas have been generated (using 'make gen-cue')
-func GrafanaContainer(d *dagger.Client, platform dagger.Platform, base string, grafana *dagger.Directory) *dagger.Container {
-	return GolangContainer(d, platform, base).
+func GrafanaContainer(d *dagger.Client, base string, grafana *dagger.Directory) *dagger.Container {
+	return GolangContainer(d, base).
 		WithMountedDirectory("/src", grafana).
 		WithWorkdir("/src").
 		WithEnvVariable("CODEGEN_VERIFY", "1").

--- a/containers/base_viceroy.go
+++ b/containers/base_viceroy.go
@@ -15,11 +15,8 @@ const (
 
 // ViceroyContainer returns a dagger container with everything set up that is needed to build Grafana's Go backend
 // with CGO using Viceroy, which makes setting up the C compiler toolchain easier.
-func ViceroyContainer(d *dagger.Client, distro executil.Distribution, platform dagger.Platform, base string) *dagger.Container {
+func ViceroyContainer(d *dagger.Client, distro executil.Distribution, base string) *dagger.Container {
 	opts := dagger.ContainerOpts{}
-	if platform != "" {
-		opts.Platform = platform
-	}
 
 	// Instead of directly using the `arch` variable here to substitute in the GoURL, we have to be careful with the Go releases.
 	// Supported releases (in the names):
@@ -27,13 +24,6 @@ func ViceroyContainer(d *dagger.Client, distro executil.Distribution, platform d
 	// * armv6l
 	// * arm64
 	goURL := fmt.Sprintf(GoURL, "amd64")
-	switch _, arch := executil.OSAndArch(distro); arch {
-	case "arm64":
-		goURL = fmt.Sprintf(GoURL, arch)
-	case "arm":
-		goURL = fmt.Sprintf(GoURL, "armv6l")
-	}
-
 	container := d.Container(opts).From(base)
 
 	// Install Go manually, and install make, git, and curl from the package manager.

--- a/containers/build_backend_platforms.go
+++ b/containers/build_backend_platforms.go
@@ -27,6 +27,7 @@ var DefaultBuildOpts = func(distro executil.Distribution, buildinfo *BuildInfo) 
 	}
 }
 
+// BuildOptsStaticARM builds Grafana statically for the armv6/v7 architectures (not armhf/arm64)
 func BuildOptsStaticARM(distro executil.Distribution, buildinfo *BuildInfo) *executil.GoBuildOpts {
 	var (
 		os, arch = executil.OSAndArch(distro)

--- a/containers/build_backends.go
+++ b/containers/build_backends.go
@@ -1,1 +1,0 @@
-package containers

--- a/containers/dependencies_golang.go
+++ b/containers/dependencies_golang.go
@@ -9,7 +9,7 @@ func WithCachedGoDependencies(container *dagger.Container, dir *dagger.Directory
 }
 
 func DownloadGolangDependencies(d *dagger.Client, gomod, gosum *dagger.File) *dagger.Directory {
-	container := GolangContainer(d, "", GoImage).
+	container := GolangContainer(d, GoImage).
 		WithWorkdir("/src").
 		WithMountedFile("/src/go.mod", gomod).
 		WithMountedFile("/src/go.sum", gosum).

--- a/containers/test_backend.go
+++ b/containers/test_backend.go
@@ -5,11 +5,11 @@ import (
 )
 
 func BackendTestShort(d *dagger.Client, dir *dagger.Directory) *dagger.Container {
-	return GrafanaContainer(d, "", GoImage, dir).
+	return GrafanaContainer(d, GoImage, dir).
 		WithExec([]string{"go", "test", "-tags", "requires_buildifer", "-short", "-covermode", "atomic", "-timeout", "5m", "./pkg/..."})
 }
 
 func BackendTestIntegration(d *dagger.Client, dir *dagger.Directory) *dagger.Container {
-	return GrafanaContainer(d, "", GoImage, dir).
+	return GrafanaContainer(d, GoImage, dir).
 		WithExec([]string{"go", "test", "-run", "Integration", "-covermode", "atomic", "-timeout", "5m", "./pkg/..."})
 }


### PR DESCRIPTION
This should speed up ARM64/ARM builds tremendously.