### PR TITLE
Update package names so that build ID comes after the version

### DIFF
--- a/pipelines/package_names.go
+++ b/pipelines/package_names.go
@@ -30,7 +30,7 @@ func TarFilename(opts TarFileOpts) string {
 		arch = strings.Join([]string{arch, archv}, "-")
 	}
 
-	p := []string{name, opts.Version, os, arch, opts.BuildID}
+	p := []string{name, opts.Version, opts.BuildID, os, arch}
 
 	return fmt.Sprintf("%s.tar.gz", strings.Join(p, "_"))
 }
@@ -44,9 +44,9 @@ func TarOptsFromFileName(filename string) TarFileOpts {
 	var (
 		name    = components[0]
 		version = components[1]
-		os      = components[2]
-		arch    = components[3]
-		buildID = components[4]
+		buildID = components[2]
+		os      = components[3]
+		arch    = components[4]
 	)
 	if archv := strings.Split(arch, "-"); len(archv) == 2 {
 		// The reverse operation of removing the 'v' for 'arm' because the golang environment variable

--- a/pipelines/package_names_test.go
+++ b/pipelines/package_names_test.go
@@ -17,7 +17,7 @@ func TestTarFilename(t *testing.T) {
 			Distro:       distro,
 		}
 
-		expected := "grafana_v1.0.1-test_plan9_amd64_333.tar.gz"
+		expected := "grafana_v1.0.1-test_333_plan9_amd64.tar.gz"
 		if name := pipelines.TarFilename(opts); name != expected {
 			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
 		}
@@ -31,7 +31,7 @@ func TestTarFilename(t *testing.T) {
 			Distro:       distro,
 		}
 
-		expected := "grafana-enterprise_v1.0.1-test_plan9_amd64_333.tar.gz"
+		expected := "grafana-enterprise_v1.0.1-test_333_plan9_amd64.tar.gz"
 		if name := pipelines.TarFilename(opts); name != expected {
 			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
 		}
@@ -45,7 +45,7 @@ func TestTarFilename(t *testing.T) {
 			Distro:       distro,
 		}
 
-		expected := "grafana-enterprise_v1.0.1-test_plan9_arm-6_333.tar.gz"
+		expected := "grafana-enterprise_v1.0.1-test_333_plan9_arm-6.tar.gz"
 		if name := pipelines.TarFilename(opts); name != expected {
 			t.Errorf("name '%s' does not match expected name '%s'", name, expected)
 		}
@@ -54,7 +54,7 @@ func TestTarFilename(t *testing.T) {
 
 func TestOptsFromFile(t *testing.T) {
 	t.Run("It should get the correct tar file opts from a valid name", func(t *testing.T) {
-		name := "grafana-enterprise_v1.0.1-test_plan9_arm-6_333.tar.gz"
+		name := "grafana-enterprise_v1.0.1-test_333_plan9_arm-6.tar.gz"
 		distro := executil.Distribution("plan9/arm/v6")
 		expect := pipelines.TarFileOpts{
 			IsEnterprise: true,


### PR DESCRIPTION
Files were getting grouped by version+arch; if multiple packages for the same version and arch were built with different build IDs, the name / ordering was getting confusing.