### PR TITLE
Add docker command

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/grafana/grafana-build/pipelines"
+	"github.com/urfave/cli/v2"
+)
+
+var DockerCommand = &cli.Command{
+	Name:   "docker",
+	Action: PipelineActionWithPackageInput(pipelines.Docker),
+	Usage:  "Using a grafana.tar.gz as input (ideally one built using the 'package' command), create a docker image",
+	Flags: JoinFlagsWithDefault(
+		PackageInputFlags,
+		PublishFlags,
+		DockerFlags,
+	),
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -112,6 +112,16 @@ var DockerFlags = []cli.Flag{
 		Name:  "push",
 		Usage: "Assuming the docker config is already set, if this flag is set, then it will push the image after building",
 	},
+	&cli.StringFlag{
+		Name:  "alpine-base",
+		Usage: "The alpine image to use as the base image when building the alpine version of the Grafana docker image",
+		Value: "alpine:latest",
+	},
+	&cli.StringFlag{
+		Name:  "ubuntu-base",
+		Usage: "The Ubuntu image to use as the base image when building the Ubuntu version of the Grafana docker image",
+		Value: "ubuntu:latest",
+	},
 }
 
 var FlagDistros = &cli.StringSliceFlag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -98,6 +98,22 @@ var GrafanaFlags = []cli.Flag{
 	},
 }
 
+// DockerFlags are used when producing docker images.
+var DockerFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "registry",
+		Usage: "Prefix the image name with the registry provided",
+	},
+	&cli.BoolFlag{
+		Name:  "save",
+		Usage: "Use 'docker save' to save the image as a tar archive. If this flag is set then the --destination flag will be used",
+	},
+	&cli.BoolFlag{
+		Name:  "push",
+		Usage: "Assuming the docker config is already set, if this flag is set, then it will push the image after building",
+	},
+}
+
 var FlagDistros = &cli.StringSliceFlag{
 	Name:  "distro",
 	Usage: "See the list of distributions with 'go tool dist list'. For variations of the same distribution, like 'armv6' or 'armv7', append an extra path part. Example: 'linux/arm/v6', or 'linux/amd64/v3'.",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ var app = &cli.App{
 		DebCommand,
 		RPMCommand,
 		CDNCommand,
+		DockerCommand,
 		WindowsInstallerCommand,
 	},
 }

--- a/containers/extracted_package.go
+++ b/containers/extracted_package.go
@@ -7,6 +7,6 @@ func ExtractedArchive(d *dagger.Client, f *dagger.File) *dagger.Directory {
 	return d.Container().From("busybox").
 		WithFile("/src/archive.tar.gz", f).
 		WithExec([]string{"mkdir", "-p", "/src/archive"}).
-		WithExec([]string{"tar", "-xzf", "/src/archive.tar.gz", "-C", "/src/archive"}).
+		WithExec([]string{"tar", "--strip-components=1", "-xzf", "/src/archive.tar.gz", "-C", "/src/archive"}).
 		Directory("/src/archive")
 }

--- a/containers/extracted_package.go
+++ b/containers/extracted_package.go
@@ -1,0 +1,12 @@
+package containers
+
+import "dagger.io/dagger"
+
+// ExtractedActive returns a directory that holds an extracted tar.gz
+func ExtractedArchive(d *dagger.Client, f *dagger.File) *dagger.Directory {
+	return d.Container().From("busybox").
+		WithFile("/src/archive.tar.gz", f).
+		WithExec([]string{"mkdir", "-p", "/src/archive"}).
+		WithExec([]string{"tar", "-xzf", "/src/archive.tar.gz", "-C", "/src/archive"}).
+		Directory("/src/archive")
+}

--- a/containers/opts_docker.go
+++ b/containers/opts_docker.go
@@ -14,12 +14,22 @@ type DockerOpts struct {
 	// Save will save the image to the local filesystem.
 	// If both Push and Save are true, then both will happen.
 	Save bool
+
+	// AlpineBase is supplied as a build-arg when building Grafana.
+	// When building alpine versions of Grafana it uses this image as its base.
+	AlpineBase string
+
+	// UbuntuBase is supplied as a build-arg when building Grafana.
+	// When building ubuntu versions of Grafana it uses this image as its base.
+	UbuntuBase string
 }
 
 func DockerOptsFromFlags(c cliutil.CLIContext) *DockerOpts {
 	return &DockerOpts{
-		Registry: c.String("registry"),
-		Push:     c.Bool("push"),
-		Save:     c.Bool("save"),
+		Registry:   c.String("registry"),
+		Push:       c.Bool("push"),
+		Save:       c.Bool("save"),
+		AlpineBase: c.String("alpine-base"),
+		UbuntuBase: c.String("ubuntu-base"),
 	}
 }

--- a/containers/opts_docker.go
+++ b/containers/opts_docker.go
@@ -1,0 +1,25 @@
+package containers
+
+import "github.com/grafana/grafana-build/cliutil"
+
+type DockerOpts struct {
+	// Registry is the docker Registry for the image.
+	// If using '--save', then this will have no effect.
+	// Uses docker hub by default.
+	// Example: us.gcr.io/12345
+	Registry string
+	// Push will push the image to the container registry if it is true
+	// If both Push and Save are true, then both will happen.
+	Push bool
+	// Save will save the image to the local filesystem.
+	// If both Push and Save are true, then both will happen.
+	Save bool
+}
+
+func DockerOptsFromFlags(c cliutil.CLIContext) *DockerOpts {
+	return &DockerOpts{
+		Registry: c.String("registry"),
+		Push:     c.Bool("push"),
+		Save:     c.Bool("save"),
+	}
+}

--- a/pipelines/cdn.go
+++ b/pipelines/cdn.go
@@ -24,7 +24,7 @@ func CDN(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 		public := d.Container().From("busybox").
 			WithFile("/src/grafana.tar.gz", targz).
 			WithExec([]string{"mkdir", "-p", "/src/grafana"}).
-			WithExec([]string{"tar", "-xzf", "/src/grafana.tar.gz", "-C", "/src/grafana"}).
+			WithExec([]string{"tar", "--strip-components=1", "-xzf", "/src/grafana.tar.gz", "-C", "/src/grafana"}).
 			WithWorkdir("/src").
 			Directory("/src/grafana/public")
 

--- a/pipelines/docker.go
+++ b/pipelines/docker.go
@@ -1,0 +1,68 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/grafana/grafana-build/containers"
+)
+
+// Docker is a pipeline that uses a grafana.tar.gz as input and creates a Docker image using that same Grafana's Dockerfile.
+// Grafana's Dockerfile should support supplying a tar.gz using the
+func Docker(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
+	packages, err := containers.GetPackages(ctx, d, args.PackageInputOpts)
+	if err != nil {
+		return err
+	}
+
+	var (
+		opts  = args.DockerOpts
+		saved = map[string]*dagger.File{}
+	)
+
+	for i, v := range args.PackageInputOpts.Packages {
+		tarOpts := TarOptsFromFileName(v)
+		name := "grafana"
+		if edition := tarOpts.Edition; edition != "" {
+			name = fmt.Sprintf("%s-%s", name, edition)
+		}
+
+		var (
+			targz      = packages[i]
+			tag        = fmt.Sprintf("%s:%s", name, tarOpts.Version)
+			src        = containers.ExtractedArchive(d, targz)
+			dockerfile = src.File("Dockerfile")
+			runsh      = src.File("packaging/docker/run.sh")
+		)
+
+		socket := d.Host().UnixSocket("/var/run/docker.sock")
+		// Docker build and give the grafana.tar.gz as a build argument
+		builder := d.Container().From("docker").
+			WithUnixSocket("/var/run/docker.sock", socket).
+			WithWorkdir("/src").
+			WithMountedFile("/src/Dockerfile", dockerfile).
+			WithMountedFile("/src/packaging/docker/run.sh", runsh).
+			WithMountedFile("/src/grafana.tar.gz", targz).
+			WithExec([]string{"docker", "buildx", "build", ".", "--build-arg=GRAFANA_TGZ=/src/grafana.tar.gz", "-t", tag})
+
+		// if --save was provided then we will publish this to the requested location using PublishFile
+		if opts.Save {
+			name := DestinationName(v, "img")
+			img := builder.WithExec([]string{"docker", "save", tag, "-o", name}).File(name)
+			saved[name] = img
+		}
+	}
+
+	for k, v := range saved {
+		dst := strings.Join([]string{args.PublishOpts.Destination, k}, "/")
+		log.Println(k, v, dst)
+		if err := containers.PublishFile(ctx, d, v, args.PublishOpts, dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pipelines/docker.go
+++ b/pipelines/docker.go
@@ -39,6 +39,7 @@ func Docker(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 		)
 
 		socket := d.Host().UnixSocket("/var/run/docker.sock")
+
 		// Docker build and give the grafana.tar.gz as a build argument
 		builder := d.Container().From("docker").
 			WithUnixSocket("/var/run/docker.sock", socket).
@@ -46,7 +47,11 @@ func Docker(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 			WithMountedFile("/src/Dockerfile", dockerfile).
 			WithMountedFile("/src/packaging/docker/run.sh", runsh).
 			WithMountedFile("/src/grafana.tar.gz", targz).
-			WithExec([]string{"docker", "buildx", "build", ".", "--build-arg=GRAFANA_TGZ=/src/grafana.tar.gz", "-t", tag})
+			WithExec([]string{"docker", "buildx", "build", ".",
+				"--build-arg=GRAFANA_TGZ=grafana.tar.gz",
+				"--build-arg=GO_SRC=tgz-builder",
+				"--build-arg=JS_SRC=tgz-builder",
+				"-t", tag})
 
 		// if --save was provided then we will publish this to the requested location using PublishFile
 		if opts.Save {

--- a/pipelines/docker.go
+++ b/pipelines/docker.go
@@ -8,7 +8,57 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/containers"
+	"github.com/grafana/grafana-build/executil"
 )
+
+type BaseImage int
+
+const (
+	BaseImageUbuntu BaseImage = iota
+	BaseImageAlpine
+)
+
+func ImageTag(registry, org, repo, version string) string {
+	return fmt.Sprintf("%s/%s/%s:%s", registry, org, repo, version)
+}
+
+// GrafanaImageTag returns the name of the grafana docker image based on the tar package name.
+// To maintain backwards compatibility, we must keep this the same as it was before.
+func GrafanaImageTags(base BaseImage, opts TarFileOpts) []string {
+	var (
+		registry = "docker.io"
+		org      = "grafana"
+		repos    = []string{"grafana-image-tags", "grafana-oss-image-tags"}
+		version  = opts.Version
+
+		edition = opts.Edition
+	)
+
+	if edition != "" {
+		// Non-grafana repositories only create images in 1 repository instead of 2. Reason unknown.
+		repos = []string{fmt.Sprintf("grafana-%s-image-tags", edition)}
+	}
+
+	// For some unknown reason, versions in docker hub do not have a 'v'.
+	// I think this was something that was established a long time ago and just stuck.
+	version = strings.TrimPrefix(version, "v")
+
+	if base == BaseImageUbuntu {
+		version += "-ubuntu"
+	}
+
+	if opts.Distro != "" && opts.Distro != "linux/amd64" {
+		_, arch := executil.OSAndArch(opts.Distro)
+		version += "-" + strings.ReplaceAll(arch, "/", "")
+	}
+
+	tags := make([]string, len(repos))
+	for i, repo := range repos {
+		tags[i] = ImageTag(registry, org, repo, version)
+	}
+
+	return tags
+}
 
 // Docker is a pipeline that uses a grafana.tar.gz as input and creates a Docker image using that same Grafana's Dockerfile.
 // Grafana's Dockerfile should support supplying a tar.gz using the
@@ -25,39 +75,56 @@ func Docker(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 
 	for i, v := range args.PackageInputOpts.Packages {
 		tarOpts := TarOptsFromFileName(v)
-		name := "grafana"
-		if edition := tarOpts.Edition; edition != "" {
-			name = fmt.Sprintf("%s-%s", name, edition)
-		}
 
 		var (
 			targz      = packages[i]
-			tag        = fmt.Sprintf("%s:%s", name, tarOpts.Version)
 			src        = containers.ExtractedArchive(d, targz)
 			dockerfile = src.File("Dockerfile")
 			runsh      = src.File("packaging/docker/run.sh")
 		)
 
-		socket := d.Host().UnixSocket("/var/run/docker.sock")
+		bases := []BaseImage{BaseImageAlpine, BaseImageUbuntu}
+		for _, base := range bases {
+			tags := GrafanaImageTags(base, tarOpts)
+			log.Println("Building docker images", tags)
+			// a different base image is used for arm versions of Grafana
+			baseImage := args.DockerOpts.AlpineBase
+			if base == BaseImageUbuntu {
+				baseImage = args.DockerOpts.UbuntuBase
+			}
 
-		// Docker build and give the grafana.tar.gz as a build argument
-		builder := d.Container().From("docker").
-			WithUnixSocket("/var/run/docker.sock", socket).
-			WithWorkdir("/src").
-			WithMountedFile("/src/Dockerfile", dockerfile).
-			WithMountedFile("/src/packaging/docker/run.sh", runsh).
-			WithMountedFile("/src/grafana.tar.gz", targz).
-			WithExec([]string{"docker", "buildx", "build", ".",
+			socket := d.Host().UnixSocket("/var/run/docker.sock")
+
+			args := []string{"docker", "buildx", "build", ".",
 				"--build-arg=GRAFANA_TGZ=grafana.tar.gz",
+				fmt.Sprintf("--build-arg=BASE_IMAGE=%s", baseImage),
 				"--build-arg=GO_SRC=tgz-builder",
 				"--build-arg=JS_SRC=tgz-builder",
-				"-t", tag})
+			}
 
-		// if --save was provided then we will publish this to the requested location using PublishFile
-		if opts.Save {
-			name := DestinationName(v, "img")
-			img := builder.WithExec([]string{"docker", "save", tag, "-o", name}).File(name)
-			saved[name] = img
+			for _, v := range tags {
+				args = append(args, "-t", v)
+			}
+
+			// Docker build and give the grafana.tar.gz as a build argument
+			builder := d.Container().From("docker").
+				WithUnixSocket("/var/run/docker.sock", socket).
+				WithWorkdir("/src").
+				WithMountedFile("/src/Dockerfile", dockerfile).
+				WithMountedFile("/src/packaging/docker/run.sh", runsh).
+				WithMountedFile("/src/grafana.tar.gz", targz).
+				WithExec(args)
+
+			// if --save was provided then we will publish this to the requested location using PublishFile
+			if opts.Save {
+				ext := "docker.tar.gz"
+				if base == BaseImageUbuntu {
+					ext = "ubuntu.docker.tar.gz"
+				}
+				name := DestinationName(v, ext)
+				img := builder.WithExec([]string{"docker", "save", tags[0], "-o", name}).File(name)
+				saved[name] = img
+			}
 		}
 	}
 

--- a/pipelines/docker_test.go
+++ b/pipelines/docker_test.go
@@ -1,0 +1,144 @@
+package pipelines_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/grafana/grafana-build/pipelines"
+)
+
+func TestImageName(t *testing.T) {
+	// Normally I don't advocate for abstracting tests using test cases
+	// but I think in this case I would really like to get a clearer view into what docker image tags will be produced.
+	// Be sure that if you add additional test cases to this that you don't use formatting or concatenation; it should be obvious when looking at the test
+	// what the expected output should be. And that value should not change based on another value.
+	type tc struct {
+		Description string
+		Tags        []string
+		BaseImage   pipelines.BaseImage
+		TarOpts     pipelines.TarFileOpts
+	}
+
+	var (
+		version = "v1.2.3-test.1.2.3"
+	)
+
+	cases := []tc{
+		{
+			Description: "Grafana docker images are created for both the 'docker.io/grafana/grafana-image-tags' and 'docker.io/grafana/grafana-oss-image-tags' repositories. AMD64 docker images have no suffix. Alpine images also have no suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "",
+				Distro:  "linux/amd64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageAlpine,
+			Tags: []string{
+				"docker.io/grafana/grafana-image-tags:1.2.3-test.1.2.3",
+				"docker.io/grafana/grafana-oss-image-tags:1.2.3-test.1.2.3",
+			},
+		},
+		{
+			Description: "Grafana docker images are created for both the 'docker.io/grafana/grafana-image-tags' and 'docker.io/grafana/grafana-oss-image-tags' repositories. ARM64 images have a -arm64 suffix. Alpine images also have no suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "",
+				Distro:  "linux/arm64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageAlpine,
+			Tags: []string{
+				"docker.io/grafana/grafana-image-tags:1.2.3-test.1.2.3-arm64",
+				"docker.io/grafana/grafana-oss-image-tags:1.2.3-test.1.2.3-arm64",
+			},
+		},
+		{
+			Description: "Grafana docker images are created for both the 'docker.io/grafana/grafana-image-tags' and 'docker.io/grafana/grafana-oss-image-tags' repositories. AMD64 docker images have no suffix. Ubuntu images have a '-ubuntu' suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "",
+				Distro:  "linux/amd64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageUbuntu,
+			Tags: []string{
+				"docker.io/grafana/grafana-image-tags:1.2.3-test.1.2.3-ubuntu",
+				"docker.io/grafana/grafana-oss-image-tags:1.2.3-test.1.2.3-ubuntu",
+			},
+		},
+		{
+			Description: "Grafana docker images are created for both the 'docker.io/grafana/grafana-image-tags' and 'docker.io/grafana/grafana-oss-image-tags' repositories. ARM64 images have an -arm64 suffix. Ubuntu images have a '-ubuntu' suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "",
+				Distro:  "linux/arm64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageUbuntu,
+			Tags: []string{
+				"docker.io/grafana/grafana-image-tags:1.2.3-test.1.2.3-ubuntu-arm64",
+				"docker.io/grafana/grafana-oss-image-tags:1.2.3-test.1.2.3-ubuntu-arm64",
+			},
+		},
+		{
+			Description: "Enterprise docker images are created for only the docker.io/grafana/grafana-enterprise-image-tags repository. AMD64 docker images have no suffix. Alpine images also have no suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "enterprise",
+				Distro:  "linux/amd64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageAlpine,
+			Tags: []string{
+				"docker.io/grafana/grafana-enterprise-image-tags:1.2.3-test.1.2.3",
+			},
+		},
+		{
+			Description: "Enterprise docker images are created for only the docker.io/grafana/grafana-enterprise-image-tags repository. ARM64 images have an -arm64 suffix. Alpine images also have no suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "enterprise",
+				Distro:  "linux/arm64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageAlpine,
+			Tags: []string{
+				"docker.io/grafana/grafana-enterprise-image-tags:1.2.3-test.1.2.3-arm64",
+			},
+		},
+		{
+			Description: "Enterprise docker images are created for only the docker.io/grafana/grafana-enterprise-image-tags repository. AMD64 docker images have no suffix. Ubuntu images have a '-ubuntu' suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "enterprise",
+				Distro:  "linux/amd64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageUbuntu,
+			Tags: []string{
+				"docker.io/grafana/grafana-enterprise-image-tags:1.2.3-test.1.2.3-ubuntu",
+			},
+		},
+		{
+			Description: "Enterprise docker images are created for only the docker.io/grafana/grafana-enterprise-image-tags repository. ARM64 images have an -arm64 suffix. Ubuntu images have a '-ubuntu' suffix.",
+			TarOpts: pipelines.TarFileOpts{
+				Edition: "enterprise",
+				Distro:  "linux/arm64",
+				Version: version,
+			},
+			BaseImage: pipelines.BaseImageUbuntu,
+			Tags: []string{
+				"docker.io/grafana/grafana-enterprise-image-tags:1.2.3-test.1.2.3-ubuntu-arm64",
+			},
+		},
+	}
+
+	for n, test := range cases {
+		t.Run(fmt.Sprintf("[%d / %d] %s", n+1, len(cases), test.Description), func(t *testing.T) {
+			expect := sort.StringSlice(test.Tags)
+			res := sort.StringSlice(pipelines.GrafanaImageTags(test.BaseImage, test.TarOpts))
+
+			for i := range expect {
+				e := expect[i]
+				r := res[i]
+				if e != r {
+					t.Errorf("[%d / %d]\nExpected '%s'\nReceived '%s'", i+1, len(expect), e, r)
+				}
+			}
+		})
+	}
+}

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -11,6 +11,7 @@ import (
 
 // PackagedPaths are paths that are included in the grafana tarball.
 var PackagedPaths = []string{
+	"Dockerfile",
 	"bin/",
 	"conf/",
 	"LICENSE",
@@ -22,6 +23,7 @@ var PackagedPaths = []string{
 	"docs/sources/",
 	"packaging/deb",
 	"packaging/rpm",
+	"packaging/docker",
 	"packaging/wrappers",
 	"packaging/autocomplete",
 }

--- a/pipelines/package_installer.go
+++ b/pipelines/package_installer.go
@@ -107,7 +107,7 @@ func PackageInstaller(ctx context.Context, d *dagger.Client, args PipelineArgs, 
 		container := opts.Container.
 			WithEnvVariable("CACHE", "1").
 			WithFile("/src/grafana.tar.gz", packages[i]).
-			WithExec([]string{"tar", "-xvf", "/src/grafana.tar.gz", "-C", "/src"}).
+			WithExec([]string{"tar", "--strip-components=1", "-xvf", "/src/grafana.tar.gz", "-C", "/src"}).
 			WithExec([]string{"ls", "-al", "/src"}).
 			WithExec(append([]string{"mkdir", "-p"}, packagePaths...)).
 			// the "wrappers" scripts are the same as grafana-cli/grafana-server but with some extra shell commands before/after execution.

--- a/pipelines/package_names_test.go
+++ b/pipelines/package_names_test.go
@@ -64,7 +64,7 @@ func TestOptsFromFile(t *testing.T) {
 		}
 		got := pipelines.TarOptsFromFileName(name)
 		if got.Edition != expect.Edition {
-			t.Errorf("got.IsEnterprise != expect.IsEnterprise, expected '%s'", expect.Edition)
+			t.Errorf("got.Edition != expect.Edition, expected '%s'", expect.Edition)
 		}
 		if got.Version != expect.Version {
 			t.Errorf("got.Version != expect.Version, expected '%s', got '%s'", expect.Version, got.Version)

--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -35,6 +35,9 @@ type PipelineArgs struct {
 
 	// GPGOpts will be populated if the GPGFlags are enabled on the current sub-command.
 	GPGOpts *containers.GPGOpts
+
+	// DockerOpts will be populated if the DockerFlags are enabled on the current sub-command.
+	DockerOpts *containers.DockerOpts
 }
 
 // PipelineArgsFromContext populates a pipelines.PipelineArgs from a CLI context.
@@ -54,5 +57,6 @@ func PipelineArgsFromContext(ctx context.Context, c cliutil.CLIContext) (Pipelin
 		PackageOpts:      containers.PackageOptsFromFlags(c),
 		PublishOpts:      containers.PublishOptsFromFlags(c),
 		PackageInputOpts: containers.PackageInputOptsFromFlags(c),
+		DockerOpts:       containers.DockerOptsFromFlags(c),
 	}, nil
 }

--- a/pipelines/windows_installer.go
+++ b/pipelines/windows_installer.go
@@ -69,7 +69,7 @@ func WindowsInstaller(ctx context.Context, d *dagger.Client, args PipelineArgs) 
 	packaging := d.Host().Directory(filepath.Dir(f.Name())).File(filepath.Base(f.Name()))
 
 	base = base.WithMountedFile("/src/src.tar.gz", packaging).
-		WithExec([]string{"tar", "-xzf", "/src/src.tar.gz", "--strip-components=3", "-C", "/src"})
+		WithExec([]string{"tar", "--strip-components=1", "-xzf", "/src/src.tar.gz", "--strip-components=3", "-C", "/src"})
 
 	for i, v := range args.PackageInputOpts.Packages {
 		var (


### PR DESCRIPTION
Adds a command, `docker` that accepts a tar.gz as input and uses the Dockerfile in that package to create a Grafana docker image.

To use:

```
go run ./cmd package
go run ./cmd docker --package=file://dist/{package}.tar.gz --save
```

This will produce a `{}.docker.tar.gz` and '{}-ubuntu.tar.gz` in the 'dist' folder, which can be imported using `docker load -i dist/{}.docker.tar.gz`.