### PR TITLE
Fix: Use --platform and its default for Node images

### DIFF
--- a/pipelines/npm.go
+++ b/pipelines/npm.go
@@ -25,6 +25,6 @@ func NPM(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 		pkgdir = containers.ExtractedArchive(d, targz, args.PackageInputOpts.Packages[0])
 	)
 
-	c := containers.NodeContainer(d, "18.12.0").WithMountedDirectory("/src", pkgdir)
+	c := containers.NodeContainer(d, "18.12.0", args.Platform).WithMountedDirectory("/src", pkgdir)
 	return containers.ExitError(ctx, c)
 }

--- a/pipelines/package.go
+++ b/pipelines/package.go
@@ -81,7 +81,7 @@ func PackageFiles(ctx context.Context, d *dagger.Client, opts PackageOpts) (map[
 	}
 
 	// install and cache the node modules
-	if err := containers.YarnInstall(ctx, d, &containers.YarnInstallOpts{
+	if err := containers.YarnInstall(ctx, d, opts.Platform, &containers.YarnInstallOpts{
 		NodeVersion: nodeVersion,
 		Directories: map[string]*dagger.Directory{
 			".yarn":           src.Directory(".yarn").WithoutDirectory("/src/.yarn/cache"),
@@ -99,9 +99,9 @@ func PackageFiles(ctx context.Context, d *dagger.Client, opts PackageOpts) (map[
 	}
 
 	var (
-		frontend    = containers.CompileFrontend(d, src, cacheOpts, nodeVersion)
-		npmPackages = containers.NPMPackages(d, src, cacheOpts, version, nodeVersion)
-		storybook   = containers.Storybook(d, src, cacheOpts, version, nodeVersion)
+		frontend    = containers.CompileFrontend(d, opts.Platform, src, cacheOpts, nodeVersion)
+		npmPackages = containers.NPMPackages(d, opts.Platform, src, cacheOpts, version, nodeVersion)
+		storybook   = containers.Storybook(d, opts.Platform, src, cacheOpts, version, nodeVersion)
 	)
 
 	name := "grafana"

--- a/pipelines/package_validate.go
+++ b/pipelines/package_validate.go
@@ -42,7 +42,7 @@ func ValidatePackage(ctx context.Context, d *dagger.Client, src *dagger.Director
 	)
 
 	log.Println("Parallel:", args.ConcurrencyOpts.Parallel)
-	
+
 	// Run them in parallel
 	for k, dir := range dirs {
 		// Join the produced destination with the protocol given by the '--destination' flag.


### PR DESCRIPTION
Fix 'main' and user the `platform` argument to set node image's platform