### PR TITLE
Make go-version configurable

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -6,6 +6,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const defaultGoVersion = "1.21.0"
+
 var FlagPackage = &cli.StringSliceFlag{
 	Name:  "package",
 	Usage: "Path to a grafana.tar.gz package used as input. This command will process each package provided separately and produce an equal number of applicable outputs",
@@ -113,6 +115,12 @@ var GrafanaFlags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:  "go-tags",
 		Usage: "Sets the go `-tags` flag when compiling the backend",
+	},
+	&cli.StringFlag{
+		Name:     "go-version",
+		Usage:    "The version of Go to be used for building the Grafana backend",
+		Required: false,
+		Value:    defaultGoVersion,
 	},
 	&cli.StringFlag{
 		Name:  "yarn-cache",

--- a/containers/base_golang.go
+++ b/containers/base_golang.go
@@ -1,11 +1,14 @@
 package containers
 
 import (
+	"log"
+
 	"dagger.io/dagger"
 )
 
 // GolangContainer returns a dagger container with everything set up that is needed to build Grafana's Go backend or run the Golang tests.
 func GolangContainer(d *dagger.Client, platform dagger.Platform, base string) *dagger.Container {
+	log.Printf("Retrieving Go container based on `%s`", base)
 	opts := dagger.ContainerOpts{
 		Platform: platform,
 	}

--- a/containers/base_viceroy.go
+++ b/containers/base_viceroy.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	GoURL        = "https://go.dev/dl/go1.20.2.linux-%s.tar.gz"
+	GoURL        = "https://go.dev/dl/go%s.linux-%s.tar.gz"
 	ViceroyImage = "rfratto/viceroy:v0.3.0"
 )
 
 // ViceroyContainer returns a dagger container with everything set up that is needed to build Grafana's Go backend
 // with CGO using Viceroy, which makes setting up the C compiler toolchain easier.
-func ViceroyContainer(d *dagger.Client, distro executil.Distribution, base string) *dagger.Container {
+func ViceroyContainer(d *dagger.Client, distro executil.Distribution, base string, goVersion string) *dagger.Container {
 	opts := dagger.ContainerOpts{
 		Platform: "linux/amd64",
 	}
@@ -25,7 +25,7 @@ func ViceroyContainer(d *dagger.Client, distro executil.Distribution, base strin
 	// * amd64
 	// * armv6l
 	// * arm64
-	goURL := fmt.Sprintf(GoURL, "amd64")
+	goURL := fmt.Sprintf(GoURL, goVersion, "amd64")
 	container := d.Container(opts).From(base)
 
 	// Install Go manually, and install make, git, and curl from the package manager.

--- a/containers/build_backend.go
+++ b/containers/build_backend.go
@@ -10,9 +10,9 @@ import (
 	"github.com/grafana/grafana-build/versions"
 )
 
-const (
-	GoImageAlpine = "golang:1.21-alpine"
-)
+func GetGoImageAlpine(version string) string {
+	return fmt.Sprintf("golang:%s-alpine", version)
+}
 
 var GrafanaCommands = []string{
 	"grafana",
@@ -38,18 +38,19 @@ type CompileBackendOpts struct {
 	BuildInfo    *BuildInfo
 	Env          map[string]string
 	GoTags       []string
+	GoVersion    string
 
 	CombinedExecutables bool
 }
 
-func goBuildImage(distro executil.Distribution, opts *executil.GoBuildOpts) string {
+func goBuildImage(distro executil.Distribution, opts *executil.GoBuildOpts, goVersion string) string {
 	os, _ := executil.OSAndArch(distro)
 
 	if os != "linux" {
 		return ViceroyImage
 	}
 
-	return GoImageAlpine
+	return GetGoImageAlpine(goVersion)
 }
 
 // This function will return the platform equivalent to the distribution.
@@ -92,15 +93,15 @@ func CompileBackendBuilder(d *dagger.Client, opts *CompileBackendOpts) *dagger.C
 	var (
 		goBuildOpts = goBuildOptsFunc(distro, buildinfo)
 		env         = executil.GoBuildEnv(goBuildOpts)
-		image       = goBuildImage(distro, goBuildOpts)
+		image       = goBuildImage(distro, goBuildOpts, opts.GoVersion)
 	)
 
-	log.Println("Creating Grafana backend build container for", distro, "on platform", platform)
+	log.Println("Creating Grafana backend build container for", distro, "on platform", platform, "using", opts.GoVersion)
 
 	builder := GolangContainer(d, platform, image)
 
 	if image == ViceroyImage {
-		builder = ViceroyContainer(d, distro, ViceroyImage)
+		builder = ViceroyContainer(d, distro, ViceroyImage, opts.GoVersion)
 	}
 
 	genGoArgs := []string{"make", "gen-go"}

--- a/containers/dependencies_golang.go
+++ b/containers/dependencies_golang.go
@@ -8,8 +8,8 @@ func WithCachedGoDependencies(container *dagger.Container, dir *dagger.Directory
 	})
 }
 
-func DownloadGolangDependencies(d *dagger.Client, platform dagger.Platform, gomod, gosum *dagger.File) *dagger.Directory {
-	container := GolangContainer(d, platform, GoImageAlpine).
+func DownloadGolangDependencies(d *dagger.Client, platform dagger.Platform, gomod, gosum *dagger.File, goVersion string) *dagger.Directory {
+	container := GolangContainer(d, platform, GetGoImageAlpine(goVersion)).
 		WithWorkdir("/src").
 		WithMountedFile("/src/go.mod", gomod).
 		WithMountedFile("/src/go.sum", gosum).

--- a/containers/opts_grafana.go
+++ b/containers/opts_grafana.go
@@ -31,6 +31,7 @@ type GrafanaOpts struct {
 	GitHubToken   string
 	Env           map[string]string
 	GoTags        []string
+	GoVersion     string
 
 	// Version will be set by the '--version' flag if provided, and returned in the 'Version' function.
 	// If not set, then the version function will attempt to retrieve the version from Grafana's package.json or some other method.
@@ -52,6 +53,7 @@ func GrafanaOptsFromFlags(ctx context.Context, c cliutil.CLIContext) (*GrafanaOp
 		buildID        = c.String("build-id")
 		gitHubToken    = c.String("github-token")
 		goTags         = c.StringSlice("go-tags")
+		goVersion      = c.String("go-version")
 	)
 
 	if buildID == "" {
@@ -98,6 +100,7 @@ func GrafanaOptsFromFlags(ctx context.Context, c cliutil.CLIContext) (*GrafanaOp
 		GitHubToken:      gitHubToken,
 		Env:              env,
 		GoTags:           goTags,
+		GoVersion:        goVersion,
 		YarnCacheHostDir: c.String("yarn-cache"),
 	}, nil
 }

--- a/containers/test_backend.go
+++ b/containers/test_backend.go
@@ -5,11 +5,11 @@ import (
 )
 
 func BackendTestShort(d *dagger.Client, platform dagger.Platform, dir *dagger.Directory) *dagger.Container {
-	return GrafanaContainer(d, platform, GoImageAlpine, dir).
+	return GrafanaContainer(d, platform, GetGoImageAlpine("1.21.0"), dir).
 		WithExec([]string{"go", "test", "-tags", "requires_buildifer", "-short", "-covermode", "atomic", "-timeout", "5m", "./pkg/..."})
 }
 
 func BackendTestIntegration(d *dagger.Client, platform dagger.Platform, dir *dagger.Directory) *dagger.Container {
-	return GrafanaContainer(d, platform, GoImageAlpine, dir).
+	return GrafanaContainer(d, platform, GetGoImageAlpine("1.21.0"), dir).
 		WithExec([]string{"go", "test", "-run", "Integration", "-covermode", "atomic", "-timeout", "5m", "./pkg/..."})
 }


### PR DESCRIPTION
This also affects the version used within viceroy-based builds.