### PR TITLE
Use viceroy for armv7 builds

### DIFF
--- a/containers/build_backend.go
+++ b/containers/build_backend.go
@@ -44,9 +44,10 @@ type CompileBackendOpts struct {
 }
 
 func goBuildImage(distro executil.Distribution, opts *executil.GoBuildOpts, goVersion string) string {
-	os, _ := executil.OSAndArch(distro)
+	os, arch := executil.OSAndArch(distro)
 
-	if os != "linux" {
+	// For arm/v7 and arm/v6 we want to use viceroy
+	if os != "linux" || arch == "arm" {
 		return ViceroyImage
 	}
 

--- a/containers/build_backend_platforms.go
+++ b/containers/build_backend_platforms.go
@@ -56,8 +56,8 @@ func BuildOptsDynamicARM(distro executil.Distribution, buildinfo *BuildInfo) *ex
 	)
 
 	return &executil.GoBuildOpts{
-		CC:                ZigCC(distro),
-		CXX:               ZigCXX(distro),
+		// CC:                ZigCC(distro),
+		// CXX:               ZigCXX(distro),
 		ExperimentalFlags: []string{},
 		OS:                os,
 		Arch:              "arm",


### PR DESCRIPTION
When building armv7, use viceroy to build them instead of zig.