### PR TITLE
fix(publish-techdocs): fix path to workflow

### DIFF
--- a/.github/workflows/publish-techdocs.yml
+++ b/.github/workflows/publish-techdocs.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
-      - '.github/workflows/publish-docs.yml'
+      - '.github/workflows/publish-techdocs.yml'
 
 jobs:
   publish-docs:


### PR DESCRIPTION
Had the wrong filename for `publish-techdocs` workflow, so docs were not pushed despite changes made to workflow file. This fixes the file name and should trigger a push of the docs.