### PR TITLE
Fixes: Only upload 1 rpi deb package

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,11 +12,16 @@ var FlagPackage = &cli.StringSliceFlag{
 	Name:  "package",
 	Usage: "Path to a grafana.tar.gz package used as input. This command will process each package provided separately and produce an equal number of applicable outputs",
 }
+var FlagNameOverride = &cli.StringFlag{
+	Name:  "name",
+	Usage: "Overrides any calculation for name in the package with the value provided here",
+}
 
 // PackageInputFlags are used for commands that require a grafana package as input.
 // These commands are exclusively used outside of the CI process and are typically used in the CD process where a grafana.tar.gz has already been created.
 var PackageInputFlags = []cli.Flag{
 	FlagPackage,
+	FlagNameOverride,
 }
 
 // GCPFlags are used in commands that need to authenticate with Google Cloud platform using the Google Cloud SDK

--- a/containers/package_input.go
+++ b/containers/package_input.go
@@ -12,11 +12,15 @@ import (
 )
 
 type PackageInputOpts struct {
+	// Name is used when overriding the artifact that is being produced. This is used in very specific scenarios where
+	// the source package's name does not match the package's metadata name.
+	Name     string
 	Packages []string
 }
 
 func PackageInputOptsFromFlags(c cliutil.CLIContext) *PackageInputOpts {
 	return &PackageInputOpts{
+		Name:     c.String("name"),
 		Packages: c.StringSlice("package"),
 	}
 }

--- a/pipelines/deb.go
+++ b/pipelines/deb.go
@@ -11,7 +11,8 @@ import (
 // It accepts publish args, so you can place the file in a local or remote destination.
 func Deb(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 	installers, err := PackageInstaller(ctx, d, args, InstallerOpts{
-		PackageType: "deb",
+		NameOverride: args.PackageInputOpts.Name,
+		PackageType:  "deb",
 		ConfigFiles: [][]string{
 			{"/src/packaging/deb/default/grafana-server", "/pkg/etc/default/grafana-server"},
 			{"/src/packaging/deb/init.d/grafana-server", "/pkg/etc/init.d/grafana-server"},

--- a/pipelines/package_installer.go
+++ b/pipelines/package_installer.go
@@ -19,6 +19,7 @@ import (
 )
 
 type InstallerOpts struct {
+	NameOverride string
 	PackageType  string
 	ConfigFiles  [][]string
 	AfterInstall string
@@ -106,16 +107,22 @@ func PackageInstaller(ctx context.Context, d *dagger.Client, args PipelineArgs, 
 			fpmArgs = append(fpmArgs, fmt.Sprintf("--architecture=%s", arch))
 		}
 
+		packageName := "grafana"
 		// Honestly we don't care about making fpm installers for non-enterprise or non-grafana flavors of grafana
 		if tarOpts.Edition == "enterprise" {
-			fpmArgs = append(fpmArgs, fmt.Sprintf("--name=grafana-%s", tarOpts.Edition))
+			packageName = fmt.Sprintf("grafana-%s", tarOpts.Edition)
 			fpmArgs = append(fpmArgs, "--description=\"Grafana Enterprise\"")
 			fpmArgs = append(fpmArgs, "--conflicts=grafana")
 		} else {
-			fpmArgs = append(fpmArgs, "--name=grafana")
 			fpmArgs = append(fpmArgs, "--description=Grafana")
 			fpmArgs = append(fpmArgs, "--license=AGPLv3")
 		}
+
+		if n := opts.NameOverride; n != "" {
+			packageName = n
+		}
+
+		fpmArgs = append(fpmArgs, fmt.Sprintf("--name=%s", packageName))
 
 		// The last fpm arg which is required to say, "use the PWD to build the package".
 		fpmArgs = append(fpmArgs, ".")

--- a/pipelines/package_installer.go
+++ b/pipelines/package_installer.go
@@ -162,8 +162,7 @@ func PackageInstaller(ctx context.Context, d *dagger.Client, args PipelineArgs, 
 		}
 
 		container = container.WithExec(fpmArgs)
-
-		dst := strings.Join([]string{args.PublishOpts.Destination, name}, "/")
+		dst := strings.Join([]string{args.PublishOpts.Destination, strings.ReplaceAll(name, tarOpts.Name, packageName)}, "/")
 		installers[dst] = container.File("/src/" + name)
 	}
 

--- a/pipelines/package_installer.go
+++ b/pipelines/package_installer.go
@@ -148,7 +148,8 @@ func PackageInstaller(ctx context.Context, d *dagger.Client, args PipelineArgs, 
 		container := opts.Container.
 			WithFile("/src/grafana.tar.gz", packages[i]).
 			WithEnvVariable("XZ_DEFAULTS", "-T0").
-			WithExec([]string{"tar", "--strip-components=1", "-xvf", "/src/grafana.tar.gz", "-C", "/src"})
+			WithExec([]string{"tar", "--exclude=storybook", "--strip-components=1", "-xvf", "/src/grafana.tar.gz", "-C", "/src"}).
+			WithExec([]string{"rm", "/src/grafana.tar.gz"})
 
 		container = container.
 			WithExec(append([]string{"mkdir", "-p"}, packagePaths...)).

--- a/pipelines/package_names.go
+++ b/pipelines/package_names.go
@@ -9,6 +9,8 @@ import (
 )
 
 type TarFileOpts struct {
+	// Name is the name of the product in the package. 99% of the time, this will be "grafana" or "grafana-enterprise".
+	Name    string
 	Version string
 	BuildID string
 	// Edition is the flavor text after "grafana-", like "enterprise".
@@ -82,11 +84,12 @@ func TarOptsFromFileName(filename string) TarFileOpts {
 	edition := ""
 	suffix := ""
 	if n := strings.Split(name, "-"); len(n) != 1 {
-		edition = n[1]
+		edition = strings.Join(n[1:], "-")
 		suffix = fmt.Sprintf("-%s", n[1])
 	}
 
 	return TarFileOpts{
+		Name:    name,
 		Edition: edition,
 		Version: version,
 		BuildID: buildID,

--- a/pipelines/package_names_test.go
+++ b/pipelines/package_names_test.go
@@ -173,26 +173,3 @@ func TestOptsFromFile(t *testing.T) {
 		}
 	})
 }
-
-func TestFullName(t *testing.T) {
-	m := map[string][]string{
-		"grafana-enterprise":                     {"grafana", "enterprise"},
-		"grafana-enterprise-rpi":                 {"grafana", "enterprise-rpi"},
-		"grafana-enterprise-rpi-and-some-others": {"grafana", "enterprise-rpi-and-some-others"},
-	}
-
-	for fullname, v := range m {
-		o := pipelines.TarFileOpts{
-			Name:    v[0],
-			Edition: v[1],
-			Version: "v1.0.0",
-			BuildID: "101",
-			// Edition is the flavor text after "grafana-", like "enterprise".
-			Distro: executil.Distribution("linux/amd64"),
-		}
-
-		if n := o.FullName(); n != fullname {
-			t.Errorf("Unexpected fullname '%s'; expected '%s' when name is '%s' and edition is '%s'", n, fullname, v[0], v[1])
-		}
-	}
-}

--- a/scripts/drone_publish_tag_all.sh
+++ b/scripts/drone_publish_tag_all.sh
@@ -7,7 +7,7 @@ set -e
 docker run --privileged --rm tonistiigi/binfmt --install all
 
 # Build all of the grafana.tar.gz packages.
-dagger run go run ./cmd \
+dagger run --silent go run ./cmd \
   package \
   --yarn-cache=${YARN_CACHE_FOLDER} \
   --distro=linux/amd64 \
@@ -27,7 +27,7 @@ dagger run go run ./cmd \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > grafana.txt &
 
 # Build the grafana-pro tar.gz package.
-dagger run go run ./cmd \
+dagger run --silent go run ./cmd \
   package \
   --yarn-cache=${YARN_CACHE_FOLDER} \
   --distro=linux/amd64 \
@@ -55,21 +55,21 @@ cat pro.txt grafana.txt > assets.txt
 go run ./scripts/copy_npm $(cat assets.txt | grep tar.gz | grep linux | grep amd64 | grep -v enterprise | grep -v pro | grep -v sha256 -m 1) > npm.txt
 
 # Copy only the linux/amd64 edition storybook into a separate folder
-dagger run go run ./cmd storybook \
+dagger run --silent go run ./cmd storybook \
   $(cat assets.txt | grep tar.gz | grep linux | grep amd64 | grep -v enterprise | grep -v pro | grep -v sha256 | awk '{print "--package=" $0}') \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > storybook.txt &
 
 # Use the non-pro, non-windows, non-darwin packages and create deb packages from them.
-dagger run go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+dagger run --silent go run ./cmd deb \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt &
 
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
-dagger run go run ./cmd rpm \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+dagger run --silent go run ./cmd rpm \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} \
@@ -79,20 +79,20 @@ dagger run go run ./cmd rpm \
   --gpg-passphrase="${$GPG_PASSPHRASE}" > rpms.txt &
 
 # For Windows we distribute zips and exes
-dagger run go run ./cmd zip \
+dagger run --silent go run ./cmd zip \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep windows | awk '{print "--package=" $0}') \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} \
   --checksum > zips.txt &
 
-dagger run go run ./cmd windows-installer \
+dagger run --silent go run ./cmd windows-installer \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep windows | awk '{print "--package=" $0}') \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} \
   --checksum > exes.txt &
 
 # Build a docker image for all Linux distros except armv6
-dagger run go run ./cmd docker \
+dagger run --silent go run ./cmd docker \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --checksum \
   --ubuntu-base="ubuntu:22.10" \
@@ -101,7 +101,7 @@ dagger run go run ./cmd docker \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > docker.txt &
 
 # Copy only the linux/amd64 edition frontends into a separate folder
-dagger run go run ./cmd cdn \
+dagger run --silent go run ./cmd cdn \
   $(cat assets.txt | grep tar.gz | grep pro | grep linux | grep amd64 | grep -v docker | grep -v sha256 | awk '{print "--package=" $0}') \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > cdn.txt &

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -81,4 +81,4 @@ dagger run --silent go run ./cmd docker \
 cat debs.txt rpms.txt zips.txt exes.txt docker.txt >> assets.txt
 
 # Move the tar.gz packages to their expected locations
-# cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease
+cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -32,7 +32,7 @@ echo "Done building tar.gz packages..."
 
 # Use the non-windows, non-darwin packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --parallel=16 \
   --checksum \
   --destination=${local_dst} \
@@ -40,7 +40,7 @@ dagger run --silent go run ./cmd deb \
 
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
 dagger run --silent go run ./cmd rpm \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --parallel=16 \
   --checksum \
   --destination=${local_dst} \

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -6,7 +6,7 @@ set -e
 # This command enables qemu emulators for building Docker images for arm64/armv6/armv7/etc on the host.
 docker run --privileged --rm tonistiigi/binfmt --install all
 
-# # Build all of the grafana.tar.gz packages.
+# Build all of the grafana.tar.gz packages.
 dagger run --silent go run ./cmd \
   package \
   --yarn-cache=${YARN_CACHE_FOLDER} \
@@ -33,7 +33,6 @@ echo "Done building tar.gz packages..."
 # Use the non-windows, non-darwin, non-rpi packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-7 | grep -v arm-6 | awk '{print "--package=" $0}') \
-  --parallel=16 \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt
@@ -41,7 +40,6 @@ dagger run --silent go run ./cmd deb \
 # Use the armv7 package to build the `rpi` specific version.
 dagger run --silent go run ./cmd deb \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
-  --parallel=16 \
   --name=grafana-enterprise-rpi \
   --checksum \
   --destination=${local_dst} \
@@ -50,7 +48,6 @@ dagger run --silent go run ./cmd deb \
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
 dagger run --silent go run ./cmd rpm \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
-  --parallel=16 \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} \
@@ -84,4 +81,4 @@ dagger run --silent go run ./cmd docker \
 cat debs.txt rpms.txt zips.txt exes.txt docker.txt >> assets.txt
 
 # Move the tar.gz packages to their expected locations
-cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease
+# cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -6,7 +6,7 @@ set -e
 # This command enables qemu emulators for building Docker images for arm64/armv6/armv7/etc on the host.
 docker run --privileged --rm tonistiigi/binfmt --install all
 
-# Build all of the grafana.tar.gz packages.
+# # Build all of the grafana.tar.gz packages.
 dagger run --silent go run ./cmd \
   package \
   --yarn-cache=${YARN_CACHE_FOLDER} \
@@ -30,13 +30,22 @@ dagger run --silent go run ./cmd \
 
 echo "Done building tar.gz packages..."
 
-# Use the non-windows, non-darwin packages and create deb packages from them.
+# Use the non-windows, non-darwin, non-rpi packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-7 | grep -v arm-6 | awk '{print "--package=" $0}') \
   --parallel=16 \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt
+
+# Use the armv7 package to build the `rpi` specific version.
+dagger run --silent go run ./cmd deb \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
+  --parallel=16 \
+  --name=grafana-enterprise-rpi \
+  --checksum \
+  --destination=${local_dst} \
+  --gcp-service-account-key-base64=${GCP_KEY_BASE64} >> debs.txt
 
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
 dagger run --silent go run ./cmd rpm \

--- a/scripts/drone_publish_tag_grafana.sh
+++ b/scripts/drone_publish_tag_grafana.sh
@@ -40,7 +40,6 @@ dagger run --silent go run ./cmd storybook \
 # Use the non-windows, non-darwin, non-rpi packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-7 | grep -v arm-6 | awk '{print "--package=" $0}') \
-  --parallel=16 \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt
@@ -48,7 +47,6 @@ dagger run --silent go run ./cmd deb \
 # Use the armv7 package to build the `rpi` specific version.
 dagger run --silent go run ./cmd deb \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
-  --parallel=16 \
   --name=grafana-rpi \
   --checksum \
   --destination=${local_dst} \
@@ -58,7 +56,6 @@ dagger run --silent go run ./cmd deb \
 dagger run --silent go run ./cmd rpm \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --checksum \
-  --parallel=16 \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} \
   --sign=true \

--- a/scripts/drone_publish_tag_grafana.sh
+++ b/scripts/drone_publish_tag_grafana.sh
@@ -37,13 +37,22 @@ dagger run --silent go run ./cmd storybook \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > storybook.txt
 
-# Use the non-windows, non-darwin packages and create deb packages from them.
+# Use the non-windows, non-darwin, non-rpi packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin  | grep -v arm-6 | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-7 | grep -v arm-6 | awk '{print "--package=" $0}') \
   --parallel=16 \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt
+
+# Use the armv7 package to build the `rpi` specific version.
+dagger run --silent go run ./cmd deb \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
+  --parallel=16 \
+  --name=grafana-rpi \
+  --checksum \
+  --destination=${local_dst} \
+  --gcp-service-account-key-base64=${GCP_KEY_BASE64} >> debs.txt
 
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
 dagger run --silent go run ./cmd rpm \

--- a/scripts/drone_publish_tag_grafana.sh
+++ b/scripts/drone_publish_tag_grafana.sh
@@ -39,7 +39,7 @@ dagger run --silent go run ./cmd storybook \
 
 # Use the non-windows, non-darwin packages and create deb packages from them.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin  | grep -v arm-6 | awk '{print "--package=" $0}') \
   --parallel=16 \
   --checksum \
   --destination=${local_dst} \
@@ -47,7 +47,7 @@ dagger run --silent go run ./cmd deb \
 
 # Make rpm installers for all the same Linux distros, and sign them because RPM packages are signed.
 dagger run --silent go run ./cmd rpm \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep -v arm-6 | awk '{print "--package=" $0}') \
   --checksum \
   --parallel=16 \
   --destination=${local_dst} \

--- a/scripts/drone_publish_tag_pro.sh
+++ b/scripts/drone_publish_tag_pro.sh
@@ -7,7 +7,7 @@ set -e
 docker run --privileged --rm tonistiigi/binfmt --install all
 
 # Build all of the grafana.tar.gz packages.
-dagger run go run ./cmd \
+dagger run --silent go run ./cmd \
   package \
   --yarn-cache=${YARN_CACHE_FOLDER} \
   --distro=linux/amd64 \
@@ -30,14 +30,14 @@ dagger run go run ./cmd \
 echo "Done building tar.gz packages..."
 
 # Use the .tar.gz packages and create deb packages from them.
-dagger run go run ./cmd deb \
+dagger run --silent go run ./cmd deb \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | awk '{print "--package=" $0}') \
   --checksum \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > debs.txt &
 
 # Build a docker image for all .tar.gz packages
-dagger run go run ./cmd docker \
+dagger run --silent go run ./cmd docker \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | awk '{print "--package=" $0}') \
   --checksum \
   --ubuntu-base="ubuntu:22.10" \
@@ -46,7 +46,7 @@ dagger run go run ./cmd docker \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > docker.txt &
 
 # Copy only the linux/amd64 edition frontends into a separate folder
-dagger run go run ./cmd cdn \
+dagger run --silent go run ./cmd cdn \
   $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | awk '{print "--package=" $0}') \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > cdn.txt &

--- a/scripts/move_packages.go
+++ b/scripts/move_packages.go
@@ -195,7 +195,7 @@ func DebHandler(name string) []string {
 			arch = "armhf"
 		}
 		// If we're building for arm then we also copy the same thing, but with the name '-rpi'. for osme reason?
-		names = []string{fullName, fullName + "-rpi"}
+		names = []string{fullName + "-rpi"}
 	}
 
 	dst := []string{}

--- a/scripts/move_packages.go
+++ b/scripts/move_packages.go
@@ -185,6 +185,14 @@ func DebHandler(name string) []string {
 			// and is in the 'downloads-enterprise2' folder instead of 'downloads'
 			enterprise2 = "-enterprise2"
 		}
+
+		if edition == "rpi" {
+			edition = "oss"
+		}
+
+		if edition == "enterprise-rpi" {
+			edition = "enterprise"
+		}
 	}
 
 	names := []string{fullName}
@@ -195,7 +203,7 @@ func DebHandler(name string) []string {
 			arch = "armhf"
 		}
 		// If we're building for arm then we also copy the same thing, but with the name '-rpi'. for osme reason?
-		names = []string{fullName + "-rpi"}
+		names = []string{fullName}
 	}
 
 	dst := []string{}

--- a/scripts/move_packages_deb_test.go
+++ b/scripts/move_packages_deb_test.go
@@ -21,14 +21,12 @@ var debMapping = []m{
 	{
 		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb",
 		output: []string{
-			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb",
 			"artifacts/downloads/v1.2.3/oss/release/grafana-rpi_1.2.3_armhf.deb",
 		},
 	},
 	{
 		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb.sha256",
 		output: []string{
-			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb.sha256",
 			"artifacts/downloads/v1.2.3/oss/release/grafana-rpi_1.2.3_armhf.deb.sha256",
 		},
 	},
@@ -71,14 +69,12 @@ var debMapping = []m{
 	{
 		input: "gs://bucket/tag/grafana-enterprise_v1.2.3_102_linux_arm-7.deb",
 		output: []string{
-			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise_1.2.3_armhf.deb",
 			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise-rpi_1.2.3_armhf.deb",
 		},
 	},
 	{
 		input: "gs://bucket/tag/grafana-enterprise_v1.2.3_102_linux_arm-7.deb.sha256",
 		output: []string{
-			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise_1.2.3_armhf.deb.sha256",
 			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise-rpi_1.2.3_armhf.deb.sha256",
 		},
 	},

--- a/scripts/move_packages_deb_test.go
+++ b/scripts/move_packages_deb_test.go
@@ -21,13 +21,25 @@ var debMapping = []m{
 	{
 		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb",
 		output: []string{
+			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb",
+		},
+	},
+	{
+		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb",
+		output: []string{
+			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb",
+		},
+	},
+	{
+		input: "gs://bucket/tag/grafana-rpi_v1.2.3_102_linux_arm-7.deb",
+		output: []string{
 			"artifacts/downloads/v1.2.3/oss/release/grafana-rpi_1.2.3_armhf.deb",
 		},
 	},
 	{
 		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb.sha256",
 		output: []string{
-			"artifacts/downloads/v1.2.3/oss/release/grafana-rpi_1.2.3_armhf.deb.sha256",
+			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb.sha256",
 		},
 	},
 	{
@@ -69,13 +81,19 @@ var debMapping = []m{
 	{
 		input: "gs://bucket/tag/grafana-enterprise_v1.2.3_102_linux_arm-7.deb",
 		output: []string{
+			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise_1.2.3_armhf.deb",
+		},
+	},
+	{
+		input: "gs://bucket/tag/grafana-enterprise-rpi_v1.2.3_102_linux_arm-7.deb",
+		output: []string{
 			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise-rpi_1.2.3_armhf.deb",
 		},
 	},
 	{
 		input: "gs://bucket/tag/grafana-enterprise_v1.2.3_102_linux_arm-7.deb.sha256",
 		output: []string{
-			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise-rpi_1.2.3_armhf.deb.sha256",
+			"artifacts/downloads/v1.2.3/enterprise/release/grafana-enterprise_1.2.3_armhf.deb.sha256",
 		},
 	},
 	{


### PR DESCRIPTION
Resolves:

* https://github.com/grafana/grafana-build/issues/140
* Issue where the tar.gz was included in the deb installer, doubling its size.
* Issue where we were creating deb packages for rpi that weren't called "grafana-rpi" or "grafana-enterprise-rpi"

Summary after this is implemented:

* We will continue producing a deb package for armhf with the metadata name grafana and grafana-enterprise.
* We will start producing a deb package for armhf with the metadata name grafana-rpi or grafana-enterprise-pri as well.
* We won't be including the entire source grafana.tar.gz in the deb packages :doh:
* We won't be including storybook in those deb packages either.