### PR TITLE
fix(npm): Print npm packages during export

### DIFF
--- a/pipelines/npm.go
+++ b/pipelines/npm.go
@@ -34,7 +34,13 @@ func NPM(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stdout, dst)
+		entries, err := artifacts.Entries(ctx)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			fmt.Fprintln(os.Stdout, dst+"/"+entry)
+		}
 	}
 	return nil
 }

--- a/scripts/move_packages.go
+++ b/scripts/move_packages.go
@@ -72,6 +72,11 @@ func NPMHandler(name string) []string {
 		file    = filepath.Base(name)
 	)
 
+	// The version part of the filename should start with a v:
+	if !strings.Contains(file, "v"+version) {
+		file = strings.Replace(file, version, "v"+version, 1)
+	}
+
 	return []string{fmt.Sprintf(npmFormat, version, file)}
 }
 

--- a/scripts/move_packages.go
+++ b/scripts/move_packages.go
@@ -47,7 +47,7 @@ const (
 
 	// 1: version
 	// 2: package name (@grafana-ui-10.0.0.tgz)
-	npmFormat = "artifacts/npm/%[1]s/npm-artifacts/%[2]s"
+	npmFormat = "artifacts/npm/v%[1]s/npm-artifacts/%[2]s"
 
 	sha256Ext = ".sha256"
 	grafana   = "grafana"
@@ -68,7 +68,7 @@ var Handlers = map[string]HandlerFunc{
 
 func NPMHandler(name string) []string {
 	var (
-		version = os.Getenv("DRONE_TAG")
+		version = strings.TrimPrefix(os.Getenv("DRONE_TAG"), "v")
 		file    = filepath.Base(name)
 	)
 

--- a/scripts/move_packages_npm_test.go
+++ b/scripts/move_packages_npm_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+var npmMapping = []m{
+	{
+		input: "file://dist/tag/grafana_10.2.0-pre_WxeEXjDuHTPB_linux_arm64/npm-artifacts/@grafana-data-10.2.0-pre.tgz",
+		output: []string{
+			"artifacts/npm/v10.2.0-pre/npm-artifacts/@grafana-data-10.2.0-pre.tgz",
+		},
+	},
+}
+
+func TestMoveNPM(t *testing.T) {
+	t.Setenv("DRONE_TAG", "10.2.0-pre")
+	for _, v := range npmMapping {
+		out := NPMHandler(v.input)
+
+		if len(out) != len(v.output) {
+			t.Errorf("expected %d in output but received %d\nexpected: %v\nreceived: %v", len(v.output), len(out), v.output, out)
+			continue
+		}
+		sort.Strings(out)
+		exp := v.output
+		sort.Strings(exp)
+
+		for i := range out {
+			got := out[i]
+			expect := exp[i]
+			if expect != got {
+				t.Errorf("\nExpected %s\nReceived %s", expect, got)
+			}
+		}
+	}
+}

--- a/scripts/move_packages_npm_test.go
+++ b/scripts/move_packages_npm_test.go
@@ -9,7 +9,7 @@ var npmMapping = []m{
 	{
 		input: "file://dist/tag/grafana_10.2.0-pre_WxeEXjDuHTPB_linux_arm64/npm-artifacts/@grafana-data-10.2.0-pre.tgz",
 		output: []string{
-			"artifacts/npm/v10.2.0-pre/npm-artifacts/@grafana-data-10.2.0-pre.tgz",
+			"artifacts/npm/v10.2.0-pre/npm-artifacts/@grafana-data-v10.2.0-pre.tgz",
 		},
 	},
 }


### PR DESCRIPTION
Previously, only the destination directory was printed which was not
enough for the move_packages command to pick those files up for
publishing.
