### PR TITLE
Use armv6 for -rpi instead of armv7

### DIFF
--- a/containers/build_backend_platforms.go
+++ b/containers/build_backend_platforms.go
@@ -70,6 +70,33 @@ func BuildOptsDynamicARM(distro executil.Distribution, buildinfo *BuildInfo) *ex
 	}
 }
 
+// BuildOptsStaticARM builds Grafana statically for the armv6/v7 architectures (not aarch64/arm64)
+func BuildOptsStaticARM(distro executil.Distribution, buildinfo *BuildInfo) *executil.GoBuildOpts {
+	var (
+		os, _ = executil.OSAndArch(distro)
+		arm   = executil.ArchVersion(distro)
+	)
+
+	return &executil.GoBuildOpts{
+		CC:                "/toolchain/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc",
+		CXX:               "/toolchain/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-cpp",
+		ExperimentalFlags: []string{},
+		OS:                os,
+		Arch:              "arm",
+		GoARM:             executil.GoARM(arm),
+		CGOEnabled:        true,
+		TrimPath:          true,
+		LDFlags: map[string][]string{
+			"-w":                  nil,
+			"-s":                  nil,
+			"-X":                  buildinfo.LDFlags(),
+			"-linkmode=external":  nil,
+			"-extldflags=-static": nil,
+		},
+		Tags: DefaultTags,
+	}
+}
+
 func BuildOptsStatic(distro executil.Distribution, buildinfo *BuildInfo) *executil.GoBuildOpts {
 	var (
 		os, arch = executil.OSAndArch(distro)
@@ -160,9 +187,9 @@ var ZigTargets = map[executil.Distribution]string{
 
 var DistributionGoOpts = map[executil.Distribution]DistroBuildOptsFunc{
 	// The Linux distros should all have an equivalent zig target in the ZigTargets map
-	executil.DistLinuxARM:          BuildOptsDynamicARM,
-	executil.DistLinuxARMv6:        BuildOptsDynamicARM,
-	executil.DistLinuxARMv7:        BuildOptsDynamicARM,
+	executil.DistLinuxARM:          BuildOptsStaticARM,
+	executil.DistLinuxARMv6:        BuildOptsStaticARM,
+	executil.DistLinuxARMv7:        BuildOptsStaticARM,
 	executil.DistLinuxARM64:        BuildOptsStatic,
 	executil.DistLinuxARM64Dynamic: BuildOptsDynamic,
 	executil.DistLinuxAMD64:        BuildOptsStatic,

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -39,7 +39,7 @@ dagger run --silent go run ./cmd deb \
 
 # Use the armv7 package to build the `rpi` specific version.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-6 | awk '{print "--package=" $0}') \
   --name=grafana-enterprise-rpi \
   --checksum \
   --destination=${local_dst} \

--- a/scripts/drone_publish_tag_grafana.sh
+++ b/scripts/drone_publish_tag_grafana.sh
@@ -49,7 +49,7 @@ dagger run --silent go run ./cmd deb \
 
 # Use the armv7 package to build the `rpi` specific version.
 dagger run --silent go run ./cmd deb \
-  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-7 | awk '{print "--package=" $0}') \
+  $(cat assets.txt | grep tar.gz | grep -v docker | grep -v sha256 | grep -v windows | grep -v darwin | grep arm-6 | awk '{print "--package=" $0}') \
   --name=grafana-rpi \
   --checksum \
   --destination=${local_dst} \

--- a/scripts/move_packages.go
+++ b/scripts/move_packages.go
@@ -211,11 +211,8 @@ func DebHandler(name string) []string {
 
 	names := []string{fullName}
 	goos, arch := executil.OSAndArch(opts.Distro)
-	arm := executil.ArchVersion(opts.Distro)
 	if arch == "arm" {
-		if arm == "7" {
-			arch = "armhf"
-		}
+		arch = "armhf"
 		// If we're building for arm then we also copy the same thing, but with the name '-rpi'. for osme reason?
 		names = []string{fullName}
 	}

--- a/scripts/move_packages_deb_test.go
+++ b/scripts/move_packages_deb_test.go
@@ -37,6 +37,12 @@ var debMapping = []m{
 		},
 	},
 	{
+		input: "gs://bucket/tag/grafana-rpi_v1.2.3_102_linux_arm-6.deb",
+		output: []string{
+			"artifacts/downloads/v1.2.3/oss/release/grafana-rpi_1.2.3_armhf.deb",
+		},
+	},
+	{
 		input: "gs://bucket/tag/grafana_v1.2.3_102_linux_arm-7.deb.sha256",
 		output: []string{
 			"artifacts/downloads/v1.2.3/oss/release/grafana_1.2.3_armhf.deb.sha256",


### PR DESCRIPTION
Fix: We shouldn't use `armv7` for `grafana-rpi` or `grafana-enterprise-rpi`. These exist because Debian does not have a separate architecture for `v6` or `v7` arm versions, just `armhf`. `grafana` or `grafana-enterprise` packages with the `armhf` version should still use `armv7` though.