### PR TITLE
Update base_cypress.go

### DIFF
--- a/containers/base_cypress.go
+++ b/containers/base_cypress.go
@@ -5,7 +5,7 @@ import (
 )
 
 func CypressImage(version string) string {
-	return "cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97"
+	return "cypress/included:13.1.0"
 }
 
 // CypressContainer returns a docker container with everything set up that is needed to build or run e2e tests.


### PR DESCRIPTION
we moved to cypress 13.1 here: https://github.com/grafana/grafana/pull/74718

not sure how this repo works exactly, but i assume it should track what's in the grafana repo? 🤔 