### PR TITLE
Enable --go-version in all scripts

### DIFF
--- a/containers/opts_grafana.go
+++ b/containers/opts_grafana.go
@@ -45,19 +45,19 @@ type GrafanaOpts struct {
 
 func GrafanaOptsFromFlags(ctx context.Context, c cliutil.CLIContext) (*GrafanaOpts, error) {
 	var (
-		version        = c.String("version")
+		version        = strings.TrimSpace(c.String("version"))
 		grafana        = c.Bool("grafana")
-		grafanaRepo    = c.String("grafana-repo")
-		grafanaDir     = c.String("grafana-dir")
-		ref            = c.String("grafana-ref")
+		grafanaRepo    = strings.TrimSpace(c.String("grafana-repo"))
+		grafanaDir     = strings.TrimSpace(c.String("grafana-dir"))
+		ref            = strings.TrimSpace(c.String("grafana-ref"))
 		enterprise     = c.Bool("enterprise")
-		enterpriseDir  = c.String("enterprise-dir")
-		enterpriseRepo = c.String("enterprise-repo")
-		enterpriseRef  = c.String("enterprise-ref")
-		buildID        = c.String("build-id")
-		gitHubToken    = c.String("github-token")
+		enterpriseDir  = strings.TrimSpace(c.String("enterprise-dir"))
+		enterpriseRepo = strings.TrimSpace(c.String("enterprise-repo"))
+		enterpriseRef  = strings.TrimSpace(c.String("enterprise-ref"))
+		buildID        = strings.TrimSpace(c.String("build-id"))
+		gitHubToken    = strings.TrimSpace(c.String("github-token"))
 		goTags         = c.StringSlice("go-tags")
-		goVersion      = c.String("go-version")
+		goVersion      = strings.TrimSpace(c.String("go-version"))
 	)
 
 	if goVersion == "" {

--- a/scripts/drone_build_nightly_grafana.sh
+++ b/scripts/drone_build_nightly_grafana.sh
@@ -21,6 +21,7 @@ dagger run --silent go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${ver} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} >> assets.txt

--- a/scripts/drone_publish_main.sh
+++ b/scripts/drone_publish_main.sh
@@ -10,5 +10,6 @@ dagger run go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --destination=${DESTINATION}/${DRONE_BUILD_EVENT} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64}

--- a/scripts/drone_publish_main_enterprise.sh
+++ b/scripts/drone_publish_main_enterprise.sh
@@ -9,5 +9,6 @@ dagger run go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --destination=${DESTINATION}/${DRONE_BUILD_EVENT} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64}

--- a/scripts/drone_publish_tag_all.sh
+++ b/scripts/drone_publish_tag_all.sh
@@ -22,6 +22,7 @@ dagger run --silent go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${DRONE_TAG} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > grafana.txt &
@@ -42,6 +43,7 @@ dagger run --silent go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${DRONE_TAG} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > pro.txt &

--- a/scripts/drone_publish_tag_enterprise.sh
+++ b/scripts/drone_publish_tag_enterprise.sh
@@ -24,6 +24,7 @@ dagger run --silent go run ./cmd \
   --grafana-ref=${DRONE_TAG} \
   --grafana-repo=https://github.com/grafana/grafana-security-mirror.git \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${DRONE_TAG} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > assets.txt

--- a/scripts/drone_publish_tag_grafana.sh
+++ b/scripts/drone_publish_tag_grafana.sh
@@ -21,6 +21,7 @@ dagger run --silent go run ./cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${DRONE_TAG} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > assets.txt

--- a/scripts/drone_publish_tag_pro.sh
+++ b/scripts/drone_publish_tag_pro.sh
@@ -28,6 +28,7 @@ dagger run --silent go run ./cmd \
   --grafana-ref=${DRONE_TAG} \
   --grafana-repo=https://github.com/grafana/grafana-security-mirror.git \
   --github-token=${GITHUB_TOKEN} \
+  --go-version=${GO_VERSION} \
   --version=${DRONE_TAG} \
   --destination=${local_dst} \
   --gcp-service-account-key-base64=${GCP_KEY_BASE64} > assets.txt


### PR DESCRIPTION
This closes #173 . Looks like the initial fix should have worked but was perhaps not used due to a cached Docker image. This enabled the `--go-version` flag now everywhere so that we notice it earlier if things break around it but also to have it consistently available.

This change also trims all the provided GrafanaOpts flags to make the checks also work with strings that might contain just whitespace characters.