### PR TITLE
Tarballs: Remove duplicated build id

### DIFF
--- a/containers/opts_grafana.go
+++ b/containers/opts_grafana.go
@@ -126,7 +126,7 @@ func (g *GrafanaOpts) DetectVersion(ctx context.Context, client *dagger.Client, 
 		return "", err
 	}
 
-	v = strings.ReplaceAll(v, "pre", g.BuildID)
+	v = strings.ReplaceAll(v, "pre", "")
 
 	log.Println("Got version", v)
 	return v, nil


### PR DESCRIPTION
Currently, the tarballs are stored as: `gs://grafana-downloads/oss/main/grafana_10.2.0-137352_137352_linux_amd64.docker.tar.gz`. The build ID appears twice. 

If pre appears, we just replace it with an empty string. Couldn't do otherwise, since the buildID gets added again here https://github.com/grafana/grafana-build/blob/main/pipelines/package_names.go#L54