### PR TITLE
Tarballs: Check if version contains build ID

### DIFF
--- a/containers/opts_grafana.go
+++ b/containers/opts_grafana.go
@@ -126,7 +126,7 @@ func (g *GrafanaOpts) DetectVersion(ctx context.Context, client *dagger.Client, 
 		return "", err
 	}
 
-	v = strings.ReplaceAll(v, "pre", "")
+	v = strings.ReplaceAll(v, "pre", g.BuildID)
 
 	log.Println("Got version", v)
 	return v, nil

--- a/pipelines/package_names.go
+++ b/pipelines/package_names.go
@@ -51,7 +51,12 @@ func TarFilename(opts TarFileOpts) string {
 		arch = strings.Join([]string{arch, archv}, "-")
 	}
 
-	p := []string{name, opts.Version, opts.BuildID, os, arch}
+	var p []string
+	if strings.Contains(opts.Version, opts.BuildID) {
+		p = []string{name, opts.Version, os, arch}
+	} else {
+		p = []string{name, opts.Version, opts.BuildID, os, arch}
+	}
 
 	return fmt.Sprintf("%s.tar.gz", strings.Join(p, "_"))
 }


### PR DESCRIPTION
Reverts last change (https://github.com/grafana/grafana-build/pull/186) due to https://drone.grafana.net/grafana/grafana/137439/5/11 - `2023/09/28 10:19:37 Got version 10.2.0-`, which is a non-semver compatible version, thus lerna fails. 

This PR checks if the build ID is already part of the version string - if it is then don't re-add it. If it's not then add. 