### PR TITLE
fix(rpm): Remove unused dependency (urw-fonts)

### DIFF
--- a/pipelines/rpm.go
+++ b/pipelines/rpm.go
@@ -53,7 +53,6 @@ func RPM(ctx context.Context, d *dagger.Client, args PipelineArgs) error {
 			"/sbin/service",
 			"fontconfig",
 			"freetype",
-			"urw-fonts",
 		},
 		ExtraArgs: []string{
 			"--rpm-posttrans=/src/packaging/rpm/control/posttrans",


### PR DESCRIPTION
This should no longer be needed as all the PNG rendering now happens in the grafana-image-renderer.