### PR TITLE
fix: For building the module cache mount whole src

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -123,7 +123,7 @@ func Builder(
 	var (
 		version  = opts.Version
 		cacheKey = "go-mod-" + version
-		cacheDir = golang.ModuleDir(d, platform, src.File("go.mod"), src.File("go.sum"), goVersion)
+		cacheDir = golang.ModuleDir(d, platform, src, goVersion)
 		cache    = d.CacheVolume(cacheKey)
 	)
 

--- a/golang/cache.go
+++ b/golang/cache.go
@@ -26,11 +26,12 @@ func WithCachedGoDependencies(container *dagger.Container, dir *dagger.Directory
 	})
 }
 
-func ModuleDir(d *dagger.Client, platform dagger.Platform, gomod, gosum *dagger.File, goVersion string) *dagger.Directory {
+func ModuleDir(d *dagger.Client, platform dagger.Platform, src *dagger.Directory, goVersion string) *dagger.Directory {
 	container := Container(d, platform, goVersion).
 		WithWorkdir("/src").
-		WithMountedFile("/src/go.mod", gomod).
-		WithMountedFile("/src/go.sum", gosum).
+		// We need to mount the whole src directory as it might contain local
+		// Go modules:
+		WithMountedDirectory("/src", src).
 		WithExec([]string{"go", "mod", "download"})
 
 	return container.Directory("/go/pkg/mod")


### PR DESCRIPTION
This is necessary for situations where we have nested Go modules.