### PR TITLE
fix(yarn): Fix dependencies on YarnInstall

### DIFF
--- a/frontend/yarn.go
+++ b/frontend/yarn.go
@@ -3,8 +3,8 @@ package frontend
 import "dagger.io/dagger"
 
 func YarnInstall(c *dagger.Client, src *dagger.Directory, version string, cache *dagger.CacheVolume) *dagger.Container {
-	return WithYarnCache(c.Container().From(NodeImage(version)), cache).
+	return WithYarnCache(NodeContainer(c, NodeImage(version), ""), cache).
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
-		WithExec([]string{"yarn", "install", "--immutable"})
+		WithExec([]string{"yarn", "install", "--immutable", "--inline-builds"})
 }


### PR DESCRIPTION
This fixes an issue on macOS/ARM where YarnInstall is run during the initial argument parsing/handling and requires Python to be installed. For some reason that is not relevant on linux/amd64.

This also enables inline logging for that initial installation to get errors logged instead of written to a logfile.