### PR TITLE
Remove v-prefix

### DIFF
--- a/artifacts/npm.go
+++ b/artifacts/npm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/arguments"
@@ -45,7 +46,7 @@ func (f *NPMPackages) BuildFile(ctx context.Context, builder *dagger.Container, 
 }
 
 func (f *NPMPackages) BuildDir(ctx context.Context, builder *dagger.Container, opts *pipeline.ArtifactContainerOpts) (*dagger.Directory, error) {
-	return frontend.NPMPackages(builder, f.Src, f.Version), nil
+	return frontend.NPMPackages(builder, f.Src, strings.TrimPrefix(f.Version, "v")), nil
 }
 
 func (f *NPMPackages) Publisher(ctx context.Context, opts *pipeline.ArtifactContainerOpts) (*dagger.Container, error) {

--- a/backend/vcsinfo.go
+++ b/backend/vcsinfo.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"dagger.io/dagger"
@@ -37,7 +38,7 @@ func WithVCSInfo(container *dagger.Container, version string, enterprise bool) (
 
 func (v *VCSInfo) X() []string {
 	flags := []string{
-		fmt.Sprintf("main.version=%s", v.Version),
+		fmt.Sprintf("main.version=%s", strings.TrimPrefix(v.Version, "v")),
 		`main.commit=$(cat ./.buildinfo.commit)`,
 		`main.buildBranch=$(cat ./.buildinfo.branch)`,
 		fmt.Sprintf("main.buildstamp=%d", v.Timestamp.Unix()),


### PR DESCRIPTION
Prior to this, the version inside the Grafana UI was shown as `vv10.2.1` and also the generated npm tarballs has names like `@grafana-ui-vv10.2.1.tgz`. This PR should fix this.