### PR TITLE
Re-add arm32 releases

### DIFF
--- a/scripts/drone_build_main.sh
+++ b/scripts/drone_build_main.sh
@@ -10,10 +10,14 @@ dagger run --silent go run ./cmd \
  artifacts \
   -a targz:grafana:linux/amd64 \
   -a targz:grafana:linux/arm64 \
+  -a targz:grafana:linux/arm/v6 \
+  -a targz:grafana:linux/arm/v7 \
   -a targz:grafana:windows/amd64 \
   -a targz:grafana:darwin/amd64 \
   -a deb:grafana:linux/amd64 \
   -a deb:grafana:linux/arm64 \
+  -a deb:grafana:linux/arm/v6 \
+  -a deb:grafana:linux/arm/v7 \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
   --yarn-cache=${YARN_CACHE_FOLDER} \

--- a/scripts/drone_build_main.sh
+++ b/scripts/drone_build_main.sh
@@ -20,6 +20,7 @@ dagger run --silent go run ./cmd \
   -a deb:grafana:linux/arm/v7 \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
+  -a docker:grafana:linux/arm/v7 \
   --yarn-cache=${YARN_CACHE_FOLDER} \
   --checksum \
   --verify \

--- a/scripts/drone_build_main_enterprise.sh
+++ b/scripts/drone_build_main_enterprise.sh
@@ -8,8 +8,12 @@ dagger run --silent go run ./cmd \
   artifacts \
   -a targz:enterprise:linux/amd64 \
   -a targz:enterprise:linux/arm64 \
+  -a targz:enterprise:linux/arm/v6 \
+  -a targz:enterprise:linux/arm/v7 \
   -a deb:enterprise:linux/amd64 \
   -a deb:enterprise:linux/arm64 \
+  -a deb:enterprise:linux/arm/v6 \
+  -a deb:enterprise:linux/arm/v7 \
   -a docker:enterprise:linux/amd64 \
   -a docker:enterprise:linux/arm64 \
   --yarn-cache=${YARN_CACHE_FOLDER} \

--- a/scripts/drone_build_nightly_grafana.sh
+++ b/scripts/drone_build_nightly_grafana.sh
@@ -4,19 +4,17 @@ local_dst="${DRONE_WORKSPACE}/dist"
 
 # This command enables qemu emulators for building Docker images for arm64/armv6/armv7/etc on the host.
 docker run --privileged --rm tonistiigi/binfmt --install all
-  # Temporarily removed:
-  # -a targz:grafana:linux/arm/v7 \
-  # -a targz:grafana:linux/arm/v6 \
-  # -a deb:grafana:linux/arm/v6:nightly \
-  # -a deb:grafana:linux/arm/v7:nightly \
-  # -a docker:grafana:linux/arm/v7 \
-  # -a docker:grafana:linux/arm/v7:ubuntu \
+
 dagger run --silent go run ./cmd \
   artifacts \
   -a targz:grafana:linux/amd64 \
   -a targz:grafana:linux/arm64 \
+  -a targz:grafana:linux/arm/v7 \
+  -a targz:grafana:linux/arm/v6 \
   -a deb:grafana:linux/amd64:nightly \
   -a deb:grafana:linux/arm64:nightly \
+  -a deb:grafana:linux/arm/v6:nightly \
+  -a deb:grafana:linux/arm/v7:nightly \
   -a rpm:grafana:linux/amd64:sign:nightly \
   -a rpm:grafana:linux/arm64:sign:nightly \
   -a targz:grafana:windows/amd64 \
@@ -27,8 +25,10 @@ dagger run --silent go run ./cmd \
   -a exe:grafana:windows/amd64 \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
+  -a docker:grafana:linux/arm/v7 \
   -a docker:grafana:linux/amd64:ubuntu \
   -a docker:grafana:linux/arm64:ubuntu \
+  -a docker:grafana:linux/arm/v7:ubuntu \
   --checksum \
   --verify \
   --build-id=${DRONE_BUILD_NUMBER} \

--- a/scripts/drone_build_tag_enterprise.sh
+++ b/scripts/drone_build_tag_enterprise.sh
@@ -10,8 +10,12 @@ dagger run --silent go run ./cmd \
   artifacts \
   -a targz:enterprise:linux/amd64 \
   -a targz:enterprise:linux/arm64 \
+  -a targz:enterprise:linux/arm/v6 \
+  -a targz:enterprise:linux/arm/v7 \
   -a deb:enterprise:linux/amd64 \
   -a deb:enterprise:linux/arm64 \
+  -a deb:enterprise:linux/arm/v6 \
+  -a deb:enterprise:linux/arm/v7 \
   -a rpm:enterprise:linux/amd64:sign \
   -a rpm:enterprise:linux/arm64:sign \
   -a targz:enterprise:windows/amd64 \

--- a/scripts/drone_build_tag_grafana.sh
+++ b/scripts/drone_build_tag_grafana.sh
@@ -22,8 +22,10 @@ dagger run --silent go run ./cmd \
   -a rpm:grafana:linux/arm64:sign \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
+  -a docker:grafana:linux/arm/v7 \
   -a docker:grafana:linux/amd64:ubuntu \
   -a docker:grafana:linux/arm64:ubuntu \
+  -a docker:grafana:linux/arm/v7:ubuntu \
   -a targz:grafana:windows/amd64 \
   -a targz:grafana:windows/arm64 \
   -a targz:grafana:darwin/amd64 \

--- a/scripts/drone_build_tag_grafana.sh
+++ b/scripts/drone_build_tag_grafana.sh
@@ -12,8 +12,12 @@ dagger run --silent go run ./cmd \
   -a storybook \
   -a targz:grafana:linux/amd64 \
   -a targz:grafana:linux/arm64 \
+  -a targz:grafana:linux/arm/v6 \
+  -a targz:grafana:linux/arm/v7 \
   -a deb:grafana:linux/amd64 \
   -a deb:grafana:linux/arm64 \
+  -a deb:grafana:linux/arm/v6 \
+  -a deb:grafana:linux/arm/v7 \
   -a rpm:grafana:linux/amd64:sign \
   -a rpm:grafana:linux/arm64:sign \
   -a docker:grafana:linux/amd64 \


### PR DESCRIPTION
Since the go compiler issue has been resolved we can reenable the release process for arm32 versions

Fixes https://github.com/grafana/grafana-build/issues/241
Part of https://github.com/grafana/grafana-delivery/issues/370