### PR TITLE
Bug: `Auto-yes` when installing nsis deps

### DIFF
--- a/exe/builder.go
+++ b/exe/builder.go
@@ -15,7 +15,7 @@ func Builder(d *dagger.Client) (*dagger.Container, error) {
 
 	debian := d.Container().From("debian:sid").
 		WithExec([]string{"apt-get", "update", "-yq"}).
-		WithExec([]string{"apt-get", "install", "tar", "nsis"})
+		WithExec([]string{"apt-get", "install", "-yq", "tar", "nsis"})
 
 	builder, err := containers.WithEmbeddedFS(d, debian, "/src", grafanabuild.WindowsPackaging)
 	if err != nil {


### PR DESCRIPTION
There's an issue when installing nsis for versioned branches reported by @aangelisc, which can be seen [here](https://drone.grafana.net/grafana/grafana/151295/1/2).
This PR fixes the issue by automatically bypassing the `Y/n` prompt.
