### PR TITLE
armv7: Add rpms for `armv7`

### DIFF
--- a/scripts/drone_build_tag_all.sh
+++ b/scripts/drone_build_tag_all.sh
@@ -28,8 +28,10 @@ dagger run go run ./cmd artifacts \
   -a deb:enterprise:linux/arm/v7 \
   -a rpm:grafana:linux/amd64:sign \
   -a rpm:grafana:linux/arm64:sign \
+  -a rpm:grafana:linux/arm/v7:sign \
   -a rpm:enterprise:linux/amd64 \
   -a rpm:enterprise:linux/arm64 \
+  -a rpm:enterprise:linux/arm/v7:sign \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
   -a docker:grafana:linux/amd64:ubuntu \

--- a/scripts/drone_build_tag_enterprise.sh
+++ b/scripts/drone_build_tag_enterprise.sh
@@ -18,6 +18,7 @@ dagger run --silent go run ./cmd \
   -a deb:enterprise:linux/arm/v7 \
   -a rpm:enterprise:linux/amd64:sign \
   -a rpm:enterprise:linux/arm64:sign \
+  -a rpm:enterprise:linux/arm/v7:sign \
   -a targz:enterprise:windows/amd64 \
   -a targz:enterprise:windows/arm64 \
   -a targz:enterprise:darwin/amd64 \

--- a/scripts/drone_build_tag_grafana.sh
+++ b/scripts/drone_build_tag_grafana.sh
@@ -20,6 +20,7 @@ dagger run --silent go run ./cmd \
   -a deb:grafana:linux/arm/v7 \
   -a rpm:grafana:linux/amd64:sign \
   -a rpm:grafana:linux/arm64:sign \
+  -a rpm:grafana:linux/arm/v7:sign \
   -a docker:grafana:linux/amd64 \
   -a docker:grafana:linux/arm64 \
   -a docker:grafana:linux/arm/v7 \


### PR DESCRIPTION
Adds `RPM` packages for `armv7` architecture. Solves [this issue](https://drone.grafana.net/grafana/grafana-security-mirror/4812/6/2).
We used to produce these kind of artifacts before we disable the 32-bit releases due to a Golang issue.