### PR TITLE
Improve how our pipelines can take advantage of dagger caching

### DIFF
--- a/artifacts/backend.go
+++ b/artifacts/backend.go
@@ -75,6 +75,7 @@ func (b *Backend) BuildDir(ctx context.Context, builder *dagger.Container, opts 
 	}
 
 	return backend.Build(
+		opts.Client,
 		builder,
 		b.Src,
 		b.Distribution,

--- a/artifacts/package_targz.go
+++ b/artifacts/package_targz.go
@@ -246,27 +246,27 @@ func (t *Tarball) BuildFile(ctx context.Context, b *dagger.Container, opts *pipe
 		return nil, err
 	}
 
-	files := map[string]*dagger.File{
-		"VERSION":            b.File("VERSION"),
-		"LICENSE":            grafanaDir.File("LICENSE"),
-		"NOTICE.md":          grafanaDir.File("NOTICE.md"),
-		"README.md":          grafanaDir.File("README.md"),
-		"Dockerfile":         grafanaDir.File("Dockerfile"),
-		"tools/zoneinfo.zip": opts.Client.Container().From(fmt.Sprintf("golang:%s", t.GoVersion)).File("/usr/local/go/lib/time/zoneinfo.zip"),
+	files := []targz.MappedFile{
+		{"VERSION", b.File("VERSION")},
+		{"LICENSE", grafanaDir.File("LICENSE")},
+		{"NOTICE.md", grafanaDir.File("NOTICE.md")},
+		{"README.md", grafanaDir.File("README.md")},
+		{"Dockerfile", grafanaDir.File("Dockerfile")},
+		{"tools/zoneinfo.zip", opts.Client.Container().From(fmt.Sprintf("golang:%s", t.GoVersion)).File("/usr/local/go/lib/time/zoneinfo.zip")},
 	}
 
-	directories := map[string]*dagger.Directory{
-		"conf":               grafanaDir.Directory("conf"),
-		"docs/sources":       grafanaDir.Directory("docs/sources"),
-		"packaging/deb":      grafanaDir.Directory("packaging/deb"),
-		"packaging/rpm":      grafanaDir.Directory("packaging/rpm"),
-		"packaging/docker":   grafanaDir.Directory("packaging/docker"),
-		"packaging/wrappers": grafanaDir.Directory("packaging/wrappers"),
-		"bin":                backendDir,
-		"public":             frontendDir,
-		"npm-artifacts":      npmDir,
-		"storybook":          storybookDir,
-		"plugins-bundled":    pluginsDir,
+	directories := []targz.MappedDirectory{
+		{"conf", grafanaDir.Directory("conf")},
+		{"docs/sources", grafanaDir.Directory("docs/sources")},
+		{"packaging/deb", grafanaDir.Directory("packaging/deb")},
+		{"packaging/rpm", grafanaDir.Directory("packaging/rpm")},
+		{"packaging/docker", grafanaDir.Directory("packaging/docker")},
+		{"packaging/wrappers", grafanaDir.Directory("packaging/wrappers")},
+		{"bin", backendDir},
+		{"public", frontendDir},
+		{"npm-artifacts", npmDir},
+		{"storybook", storybookDir},
+		{"plugins-bundled", pluginsDir},
 	}
 
 	root := fmt.Sprintf("grafana-%s", version)

--- a/backend/build.go
+++ b/backend/build.go
@@ -9,17 +9,22 @@ import (
 	"dagger.io/dagger"
 )
 
-func GoLDFlags(flags map[string][]string) string {
+type LDFlag struct {
+	Name   string
+	Values []string
+}
+
+func GoLDFlags(flags []LDFlag) string {
 	ldflags := strings.Builder{}
-	for k, v := range flags {
-		if v == nil {
-			ldflags.WriteString(k + " ")
+	for _, v := range flags {
+		if v.Values == nil {
+			ldflags.WriteString(v.Name + " ")
 			continue
 		}
 
-		for _, value := range v {
+		for _, value := range v.Values {
 			// For example, "-X 'main.version=v1.0.0'"
-			ldflags.WriteString(fmt.Sprintf(`%s \"%s\" `, k, value))
+			ldflags.WriteString(fmt.Sprintf(`%s \"%s\" `, v.Name, value))
 		}
 	}
 
@@ -27,7 +32,7 @@ func GoLDFlags(flags map[string][]string) string {
 }
 
 // GoBuildCommand returns the arguments for go build to be used in 'WithExec'.
-func GoBuildCommand(output string, ldflags map[string][]string, tags []string, main string) []string {
+func GoBuildCommand(output string, ldflags []LDFlag, tags []string, main string) []string {
 	args := []string{"go", "build",
 		fmt.Sprintf("-ldflags=\"%s\"", GoLDFlags(ldflags)),
 		fmt.Sprintf("-o=%s", output),

--- a/backend/distributions.go
+++ b/backend/distributions.go
@@ -192,19 +192,19 @@ func Platform(d Distribution) dagger.Platform {
 
 type DistroBuildOptsFunc func(distro Distribution, experiments []string, tags []string) *GoBuildOpts
 
-func LDFlagsStatic(info *VCSInfo) map[string][]string {
-	return map[string][]string{
-		"-w":                  nil,
-		"-s":                  nil,
-		"-X":                  info.X(),
-		"-linkmode=external":  nil,
-		"-extldflags=-static": nil,
+func LDFlagsStatic(info *VCSInfo) []LDFlag {
+	return []LDFlag{
+		{"-w", nil},
+		{"-s", nil},
+		{"-X", info.X()},
+		{"-linkmode=external", nil},
+		{"-extldflags=-static", nil},
 	}
 }
 
-func LDFlagsDynamic(info *VCSInfo) map[string][]string {
-	return map[string][]string{
-		"-X": info.X(),
+func LDFlagsDynamic(info *VCSInfo) []LDFlag {
+	return []LDFlag{
+		{"-X", info.X()},
 	}
 }
 

--- a/backend/env.go
+++ b/backend/env.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"strings"
+
+	"github.com/grafana/grafana-build/containers"
 )
 
 type (
@@ -62,75 +64,76 @@ type GoBuildOpts struct {
 }
 
 // GoBuildEnv returns the environment variables that must be set for a 'go build' command given the provided 'GoBuildOpts'.
-func GoBuildEnv(opts *GoBuildOpts) map[string]string {
+func GoBuildEnv(opts *GoBuildOpts) []containers.Env {
 	var (
 		os   = opts.OS
 		arch = opts.Arch
 	)
 
-	env := map[string]string{"GOOS": os, "GOARCH": arch}
+	env := []containers.Env{{"GOOS", os}, {"GOARCH", arch}}
 
 	if arch == "arm" {
-		env["GOARM"] = string(opts.GoARM)
+		env = append(env, containers.Env{"GOARM", string(opts.GoARM)})
 	}
 
 	if opts.CGOEnabled {
-		env["CGO_ENABLED"] = "1"
+		env = append(env, containers.Env{"GOARM", string(opts.GoARM)})
+		env = append(env, containers.Env{"CGO_ENABLED", "1"})
 
 		// https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1635253695
-		env["CGO_CFLAGS"] = "-D_LARGEFILE64_SOURCE"
+		env = append(env, containers.Env{"CGO_CFLAGS", "-D_LARGEFILE64_SOURCE"})
 	} else {
-		env["CGO_ENABLED"] = "0"
+		env = append(env, containers.Env{"CGO_ENABLED", "0"})
 	}
 
 	if opts.ExperimentalFlags != nil {
-		env["GOEXPERIMENT"] = strings.Join(opts.ExperimentalFlags, ",")
+		env = append(env, containers.Env{"GOEXPERIMENT", strings.Join(opts.ExperimentalFlags, ",")})
 	}
 
 	if opts.CC != "" {
-		env["CC"] = opts.CC
+		env = append(env, containers.Env{"CC", opts.CC})
 	}
 
 	if opts.CXX != "" {
-		env["CXX"] = opts.CXX
+		env = append(env, containers.Env{"CXX", opts.CXX})
 	}
 
 	return env
 }
 
 // ViceroyEnv returns the environment variables that must be set for a 'go build' command given the provided 'GoBuildOpts'.
-func ViceroyEnv(opts *GoBuildOpts) map[string]string {
+func ViceroyEnv(opts *GoBuildOpts) []containers.Env {
 	var (
 		os   = opts.OS
 		arch = opts.Arch
 	)
 
-	env := map[string]string{
-		"VICEROYOS":   os,
-		"GOOS":        os,
-		"VICEROYARCH": arch,
-		"GOARCH":      arch,
+	env := []containers.Env{
+		{"VICEROYOS", os},
+		{"GOOS", os},
+		{"VICEROYARCH", arch},
+		{"GOARCH", arch},
 	}
 
 	if arch == "arm" {
-		env["VICEROYARM"] = string(opts.GoARM)
+		env = append(env, containers.Env{"VICEROYARM", string(opts.GoARM)})
 	}
 
 	if opts.CGOEnabled {
-		env["CGO_ENABLED"] = "1"
+		env = append(env, containers.Env{"CGO_ENABLED", "1"})
 
 		// https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1635253695
-		env["CGO_CFLAGS"] = "-D_LARGEFILE64_SOURCE"
+		env = append(env, containers.Env{"CGO_CFLAGS", "-D_LARGEFILE64_SOURCE"})
 	} else {
-		env["CGO_ENABLED"] = "0"
+		env = append(env, containers.Env{"CGO_ENABLED", "0"})
 	}
 
 	if opts.ExperimentalFlags != nil {
-		env["GOEXPERIMENT"] = strings.Join(opts.ExperimentalFlags, ",")
+		env = append(env, containers.Env{"GOEXPERIMENT", strings.Join(opts.ExperimentalFlags, ",")})
 	}
 
 	if opts.CC != "" {
-		env["CC"] = "viceroycc"
+		env = append(env, containers.Env{"CC", "viceroycc"})
 	}
 
 	return env

--- a/backend/vcsinfo.go
+++ b/backend/vcsinfo.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"dagger.io/dagger"
 )
@@ -13,27 +12,40 @@ type VCSInfo struct {
 	Commit           *dagger.File
 	EnterpriseCommit *dagger.File
 	Branch           *dagger.File
-	Timestamp        time.Time
 }
 
-// GetVCSInfo gets the VCS data from the directory 'src', writes them to a file on the given container, and returns the files which can be used in other containers.
-func WithVCSInfo(container *dagger.Container, version string, enterprise bool) (*dagger.Container, *VCSInfo) {
-	c := container.
+func WithVCSInfo(c *dagger.Container, info *VCSInfo, enterprise bool) *dagger.Container {
+	c = c.
+		WithFile(".buildinfo.commit", info.Commit).
+		WithFile(".buildinfo.branch", info.Branch)
+
+	if enterprise {
+		return c.WithFile(".buildinfo.enterprise-commit", info.EnterpriseCommit)
+	}
+
+	return c
+}
+
+// VCSInfo gets the VCS data from the directory 'src', writes them to a file on the given container, and returns the files which can be used in other containers.
+func GetVCSInfo(d *dagger.Client, src *dagger.Directory, version string, enterprise bool) *VCSInfo {
+	c := d.Container().From("alpine/git").
+		WithEntrypoint([]string{}).
+		WithMountedDirectory("/src/.git", src.Directory(".git")).
+		WithWorkdir("/src").
 		WithExec([]string{"/bin/sh", "-c", "git rev-parse HEAD > .buildinfo.commit"}).
 		WithExec([]string{"/bin/sh", "-c", "git rev-parse --abbrev-ref HEAD > .buildinfo.branch"})
 
 	info := &VCSInfo{
-		Version:   version,
-		Commit:    c.File(".buildinfo.commit"),
-		Branch:    c.File(".buildinfo.branch"),
-		Timestamp: time.Now(),
+		Version: version,
+		Commit:  c.File(".buildinfo.commit"),
+		Branch:  c.File(".buildinfo.branch"),
 	}
 
 	if enterprise {
 		info.EnterpriseCommit = c.File(".buildinfo.enterprise-commit")
 	}
 
-	return c, info
+	return info
 }
 
 func (v *VCSInfo) X() []string {
@@ -41,7 +53,6 @@ func (v *VCSInfo) X() []string {
 		fmt.Sprintf("main.version=%s", strings.TrimPrefix(v.Version, "v")),
 		`main.commit=$(cat ./.buildinfo.commit)`,
 		`main.buildBranch=$(cat ./.buildinfo.branch)`,
-		fmt.Sprintf("main.buildstamp=%d", v.Timestamp.Unix()),
 	}
 
 	if v.EnterpriseCommit != nil {

--- a/containers/withenv.go
+++ b/containers/withenv.go
@@ -4,10 +4,15 @@ import (
 	"dagger.io/dagger"
 )
 
-func WithEnv(c *dagger.Container, env map[string]string) *dagger.Container {
+type Env struct {
+	Name  string
+	Value string
+}
+
+func WithEnv(c *dagger.Container, env []Env) *dagger.Container {
 	container := c
-	for k, v := range env {
-		container = container.WithEnvVariable(k, v)
+	for _, v := range env {
+		container = container.WithEnvVariable(v.Name, v.Value)
 	}
 
 	return container

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -9,7 +9,26 @@ func Builder(d *dagger.Client, platform dagger.Platform, src *dagger.Directory, 
 	container := WithYarnCache(
 		NodeContainer(d, NodeImage(nodeVersion), platform),
 		cache,
-	).WithMountedDirectory("/src", src).WithWorkdir("/src")
+	).
+		WithDirectory("/src",
+			src.
+				WithoutFile("go.mod").
+				WithoutFile("go.sum").
+				WithoutDirectory(".git").
+				WithoutDirectory("devenv").
+				WithoutDirectory(".github").
+				WithoutDirectory("scripts").
+				WithoutDirectory("docs").
+				WithoutDirectory("pkg"),
+			dagger.ContainerWithDirectoryOpts{
+				Exclude: []string{
+					"*drone*",
+					"*.go",
+					"*.md",
+				},
+			},
+		).
+		WithWorkdir("/src")
 
 	// TODO: Should figure out exactly what we can include without all the extras so we can take advantage of caching better.
 	// This had to be commented because storybook builds on branches older than 10.1.x were failing.

--- a/targz/build.go
+++ b/targz/build.go
@@ -31,11 +31,6 @@ type Opts struct {
 func Build(packager *dagger.Container, opts *Opts) *dagger.File {
 	root := opts.Root
 
-	for _, v := range opts.Directories {
-		packager = packager.
-			WithMountedDirectory(path.Join("/src", root, v.Path), v.Directory)
-	}
-
 	packager = packager.
 		WithWorkdir("/src")
 


### PR DESCRIPTION
Mostly this involves:

1. Avoiding the use of maps and iterating over maps. Because maps are not always in the same order, this can cause repeated executions to be defined slightly differently, resulting in cache misses.
2. Only copy files or directories that we actually need. There's more to do here for other steps, like the frontend specifically, but the biggest offender was the backend.

You can see the effect of this if you run the same command more than once.

You should see that the entire thing is cached on repeated runs.
![image](https://github.com/grafana/grafana-build/assets/5140827/59d5e18f-0ef9-4084-a68d-5ecc0d9348aa)

Tested on:

* 9.5.x
* 10.0.x
* 10.1.x
* 10.4.x
* on arm32/64, amd64, and arm64 builds.

There's still some work to be done but this should improve our caching story a bit without breaking anything.