### PR TITLE
Fix failing rgm-package step

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -151,6 +151,14 @@ func Builder(
 		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag)).
 		WithWorkdir("/src")
 
+	commitInfo := GetVCSInfo(d, src, version, opts.Enterprise)
+
+	if opts.Enterprise {
+		builder = builder.WithFile("/src/.buildinfo.enterprise-commit", commitInfo.EnterpriseCommit)
+	} else {
+		builder = builder.WithFile("/src/.buildinfo.commit", commitInfo.Commit)
+	}
+
 	builder = golang.WithCachedGoDependencies(
 		builder,
 		cacheDir, cache,

--- a/backend/builder.go
+++ b/backend/builder.go
@@ -134,6 +134,8 @@ func Builder(
 		return nil, err
 	}
 
+	commitInfo := GetVCSInfo(d, src, version, opts.Enterprise)
+
 	builder = builder.
 		WithDirectory("/src/pkg", src.Directory("pkg")).
 		WithDirectory("/src/emails", src.Directory("emails")).
@@ -149,14 +151,11 @@ func Builder(
 		WithFile("/src/go.sum", src.File("go.sum")).
 		WithFile("/src/embed.go", src.File("embed.go")).
 		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag)).
+		WithFile("/src/.buildinfo.commit", commitInfo.Commit).
 		WithWorkdir("/src")
-
-	commitInfo := GetVCSInfo(d, src, version, opts.Enterprise)
 
 	if opts.Enterprise {
 		builder = builder.WithFile("/src/.buildinfo.enterprise-commit", commitInfo.EnterpriseCommit)
-	} else {
-		builder = builder.WithFile("/src/.buildinfo.commit", commitInfo.Commit)
 	}
 
 	builder = golang.WithCachedGoDependencies(

--- a/backend/vcsinfo.go
+++ b/backend/vcsinfo.go
@@ -30,7 +30,7 @@ func WithVCSInfo(c *dagger.Container, info *VCSInfo, enterprise bool) *dagger.Co
 func GetVCSInfo(d *dagger.Client, src *dagger.Directory, version string, enterprise bool) *VCSInfo {
 	c := d.Container().From("alpine/git").
 		WithEntrypoint([]string{}).
-		WithMountedDirectory("/src/.git", src.Directory(".git")).
+		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
 		WithExec([]string{"/bin/sh", "-c", "git rev-parse HEAD > .buildinfo.commit"}).
 		WithExec([]string{"/bin/sh", "-c", "git rev-parse --abbrev-ref HEAD > .buildinfo.branch"})


### PR DESCRIPTION
`rgm-package` step fails in enterprise with error:

```
error exporting artifact 'grafana-enterprise_10.4.0-66421_66421_linux_arm64.tar.gz': input: resolve: container: from: withEntrypoint: withMountedDirectory: withWorkdir: withExec: withExec: file: lstat /src/.buildinfo.enterprise-commit: no such file or directory
```

e.g.: https://drone.grafana.net/grafana/grafana-enterprise/66421/3/9