### PR TITLE
Fix issue with make gen-go and storybook on 9.5.x

### DIFF
--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -14,7 +14,6 @@ func Builder(d *dagger.Client, platform dagger.Platform, src *dagger.Directory, 
 			src.
 				WithoutFile("go.mod").
 				WithoutFile("go.sum").
-				WithoutDirectory(".git").
 				WithoutDirectory("devenv").
 				WithoutDirectory(".github").
 				WithoutDirectory("docs").


### PR DESCRIPTION
For some older (still supported) versions of Grafana:
* some extra directories are needed when running `make gen-go`.
* some extra directories are needed when building storybook packages.