### PR TITLE
Add support for go.work

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -154,6 +154,8 @@ func Builder(
 		WithDirectory("/src/emails", src.Directory("emails")).
 		WithFile("/src/go.mod", src.File("go.mod")).
 		WithFile("/src/go.sum", src.File("go.sum")).
+		WithFile("/src/go.work", src.File("go.work")).
+		WithFile("/src/go.work.sum", src.File("go.work.sum")).
 		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag)).
 		WithFile("/src/.buildinfo.commit", commitInfo.Commit).
 		WithWorkdir("/src")
@@ -179,6 +181,8 @@ func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goV
 		WithFile("/src/Makefile", src.File("Makefile")).
 		WithFile("/src/go.mod", src.File("go.mod")).
 		WithFile("/src/go.sum", src.File("go.sum")).
+		WithFile("/src/go.work", src.File("go.work")).
+		WithFile("/src/go.work.sum", src.File("go.work.sum")).
 		WithWorkdir("/src").
 		WithExec([]string{"make", "gen-go", fmt.Sprintf("WIRE_TAGS=%s", wireTag)}).
 		File("/src/pkg/server/wire_gen.go")

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -14,6 +14,8 @@ func Builder(d *dagger.Client, platform dagger.Platform, src *dagger.Directory, 
 			src.
 				WithoutFile("go.mod").
 				WithoutFile("go.sum").
+				WithoutFile("go.work").
+				WithoutFile("go.work.sum").
 				WithoutDirectory("devenv").
 				WithoutDirectory(".github").
 				WithoutDirectory("docs").


### PR DESCRIPTION
It seems like `go.work` and `go.work.sum` are not being used in the `rgm-package` step based on [this error](https://drone.grafana.net/grafana/grafana/162715/6/11):

```
wire: /src/pkg/services/apiserver/wireset.go:14:2: first argument to Bind must be a pointer to an interface type; found <nil>
```