### PR TITLE
Add GBS squad in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @grafana/grafana-release-guild
-
+* @grafana/grafana-release-guild @grafana/grafana-backend-services-squad


### PR DESCRIPTION
The Grafana Backend Services squad is taking ownership of the CI/CD/Release/etc stuff, so we'll need to be codeowners here 😉

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
