### PR TITLE
Move grafana-server init script to /etc/rc.d/init.d

### DIFF
--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -85,7 +85,7 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		NameOverride: d.NameOverride,
 		ConfigFiles: [][]string{
 			{"/src/packaging/rpm/sysconfig/grafana-server", "/pkg/etc/sysconfig/grafana-server"},
-			{"/src/packaging/rpm/init.d/grafana-server", "/pkg/etc/init.d/grafana-server"},
+			{"/src/packaging/rpm/init.d/grafana-server", "/pkg/etc/rc.d/init.d/grafana-server"},
 			{"/src/packaging/rpm/systemd/grafana-server.service", "/pkg/usr/lib/systemd/system/grafana-server.service"},
 		},
 		AfterInstall: "/src/packaging/rpm/control/postinst",


### PR DESCRIPTION
This resolves conflict with chkconfig OS package https://github.com/grafana/grafana/issues/73970

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
