### PR TITLE
Add --patches-repo, --patches-path, and --patches-ref flags

### DIFF
--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path"
+	"path/filepath"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/cliutil"
@@ -50,6 +52,10 @@ type GrafanaDirectoryOpts struct {
 	EnterpriseRef string
 	// GitHubToken is used when cloning Grafana/Grafana Enterprise.
 	GitHubToken string
+
+	PatchesRepo string
+	PatchesPath string
+	PatchesRef  string
 }
 
 func (o *GrafanaDirectoryOpts) githubToken(ctx context.Context) (string, error) {
@@ -81,19 +87,17 @@ func GrafanaDirectoryOptsFromFlags(ctx context.Context, c cliutil.CLIContext) (*
 		GrafanaRef:     c.String("grafana-ref"),
 		EnterpriseRef:  c.String("enterprise-ref"),
 		GitHubToken:    c.String("github-token"),
+		PatchesRepo:    c.String("patches-repo"),
+		PatchesPath:    c.String("patches-path"),
+		PatchesRef:     c.String("patches-ref"),
 	}, nil
 }
 
-func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, ref string, o *GrafanaDirectoryOpts) (*dagger.Directory, error) {
+func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, ref string, ght string) (*dagger.Directory, error) {
 	// If GrafanaDir was provided, then we can just use that one.
 	if path := localPath; path != "" {
 		slog.Info("Using local Grafana found", "path", path)
 		return daggerutil.HostDir(client, path)
-	}
-
-	ght, err := o.githubToken(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	src, err := git.CloneWithGitHubToken(client, ght, repo, ref)
@@ -104,15 +108,81 @@ func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, r
 	return src, nil
 }
 
+func applyPatches(ctx context.Context, client *dagger.Client, src *dagger.Directory, repo, patchesPath, ref, ght string) (*dagger.Directory, error) {
+	// Clone the patches repository on 'main'
+	dir, err := git.CloneWithGitHubToken(client, ght, repo, ref)
+	if err != nil {
+		return nil, fmt.Errorf("error cloning patches repository: %w", err)
+	}
+
+	entries, err := dir.Entries(ctx, dagger.DirectoryEntriesOpts{
+		Path: patchesPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing entries in repository: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no patches in the given path")
+	}
+
+	container := client.Container().From(git.GitImage).
+		WithEntrypoint([]string{}).
+		WithMountedDirectory("/src", src).
+		WithMountedDirectory("/patches", dir).
+		WithWorkdir("/src").
+		WithExec([]string{"git", "config", "--local", "user.name", "grafana"}).
+		WithExec([]string{"git", "config", "--local", "user.email", "engineering@grafana.com"})
+
+	branch, err := container.
+		WithExec([]string{"/bin/sh", "-c", "git rev-parse --abbrev-ref HEAD"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading branch name: %w", err)
+	}
+
+	for _, v := range entries {
+		if filepath.Ext(v) != ".patch" {
+			continue
+		}
+
+		base := filepath.Base(v)
+		container = container.WithExec([]string{"/bin/sh", "-c", `git checkout -b tmp`}).
+			WithExec([]string{"/bin/sh", "-c", fmt.Sprintf(`git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date %s > /dev/null 2>&1`, path.Join("/patches", patchesPath, v))}).
+			WithExec([]string{"/bin/sh", "-c", fmt.Sprintf(`git checkout %s`, branch)}).
+			WithExec([]string{"/bin/sh", "-c", `git merge --squash tmp`}).
+			WithExec([]string{"/bin/sh", "-c", fmt.Sprintf(`git commit -m "apply security patch: %s"`, path.Join(patchesPath, base))}).
+			WithExec([]string{"/bin/sh", "-c", `git branch -D tmp`})
+	}
+
+	return container.Directory("/src"), nil
+}
+
 func grafanaDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, error) {
 	o, err := GrafanaDirectoryOptsFromFlags(ctx, opts.CLIContext)
 	if err != nil {
 		return nil, err
 	}
 
-	src, err := cloneOrMount(ctx, opts.Client, o.GrafanaDir, o.GrafanaRepo, o.GrafanaRef, o)
+	ght, err := o.githubToken(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	src, err := cloneOrMount(ctx, opts.Client, o.GrafanaDir, o.GrafanaRepo, o.GrafanaRef, ght)
+	if err != nil {
+		return nil, err
+	}
+
+	if o.PatchesRepo != "" {
+		withPatches, err := applyPatches(ctx, opts.Client, src, o.PatchesRepo, o.PatchesPath, o.PatchesRef, ght)
+		if err != nil {
+			opts.Log.Debug("patch application skipped", "error", err)
+		} else {
+			// Only replace src when there was no error.
+			src = withPatches
+		}
 	}
 
 	nodeVersion, err := frontend.NodeVersion(opts.Client, src).Stdout(ctx)
@@ -146,7 +216,12 @@ func enterpriseDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any,
 		return nil, fmt.Errorf("error initializing grafana directory: %w", err)
 	}
 
-	src, err := cloneOrMount(ctx, opts.Client, o.EnterpriseDir, o.EnterpriseRepo, o.EnterpriseRef, o)
+	ght, err := o.githubToken(ctx)
+	if err != nil {
+		return nil, nil
+	}
+
+	src, err := cloneOrMount(ctx, opts.Client, o.EnterpriseDir, o.EnterpriseRepo, o.EnterpriseRef, ght)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +266,21 @@ var GrafanaDirectoryFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:     "github-token",
-		Usage:    "Github token to use for git cloning, by default will be pulled from GitHub",
+		Usage:    "GitHub token to use for git cloning, by default will be pulled from GitHub",
 		Required: false,
+	},
+	&cli.StringFlag{
+		Name:  "patches-repo",
+		Usage: "GitHub repository that contains git patches to apply to the Grafana source code. Must be an https git URL",
+	},
+	&cli.StringFlag{
+		Name:  "patches-path",
+		Usage: "Path to folder containing '.patch' files to apply",
+	},
+	&cli.StringFlag{
+		Name:  "patches-ref",
+		Usage: "Ref to checkout in the patches repository",
+		Value: "main",
 	},
 }
 

--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -100,12 +100,7 @@ func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, r
 		return daggerutil.HostDir(client, path)
 	}
 
-	src, err := git.CloneWithGitHubToken(client, ght, repo, ref)
-	if err != nil {
-		return nil, err
-	}
-
-	return src, nil
+	return git.CloneWithGitHubToken(client, ght, repo, ref)
 }
 
 func applyPatches(ctx context.Context, client *dagger.Client, src *dagger.Directory, repo, patchesPath, ref, ght string) (*dagger.Directory, error) {

--- a/scripts/drone_build_main_enterprise.sh
+++ b/scripts/drone_build_main_enterprise.sh
@@ -27,6 +27,8 @@ dagger run --silent go run ./cmd \
   --go-version=${GO_VERSION} \
   --ubuntu-base=${UBUNTU_BASE} \
   --alpine-base=${ALPINE_BASE} \
+  --patches-repo=${PATCHES_REPO} \
+  --patches-path=${PATCHES_PATH} \
   --destination=${local_dst} > assets.txt
 
 cat assets.txt

--- a/scripts/drone_build_main_pro.sh
+++ b/scripts/drone_build_main_pro.sh
@@ -23,6 +23,8 @@ dagger run --silent go run ./cmd \
   --go-version=${GO_VERSION} \
   --ubuntu-base=${UBUNTU_BASE} \
   --alpine-base=${ALPINE_BASE} \
+  --patches-repo=${PATCHES_REPO} \
+  --patches-path=${PATCHES_PATH} \
   --destination=${local_dst} > assets.txt
 
 echo "Final list of artifacts:"


### PR DESCRIPTION
Adds the ability to specify a git repository that has git patches in it. Those git patches will be applied after the Grafana repository is cloned.

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
