### PR TITLE
build: install otel-cli from upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM ghcr.io/equinix-labs/otel-cli:0.4.5 as otel-cli
+
+FROM alpine:3.19 AS dagger
+
+# TODO: pull the binary from registry.dagger.io/cli:v0.9.8 (or similar) when
+# https://github.com/dagger/dagger/issues/6887 is resolved
+ARG DAGGER_VERSION=v0.9.8
+ADD https://github.com/dagger/dagger/releases/download/${DAGGER_VERSION}/dagger_${DAGGER_VERSION}_linux_amd64.tar.gz /tmp
+RUN tar zxf /tmp/dagger_${DAGGER_VERSION}_linux_amd64.tar.gz -C /tmp
+RUN mv /tmp/dagger /bin/dagger
+
 FROM golang:1.21-alpine
 
 ARG DAGGER_VERSION=v0.9.8
@@ -6,11 +17,8 @@ WORKDIR /src
 RUN apk add --no-cache git wget bash jq
 RUN apk add --no-cache docker --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 
-# Install dagger & otel-cli
-RUN wget "https://github.com/dagger/dagger/releases/download/${DAGGER_VERSION}/dagger_${DAGGER_VERSION}_linux_amd64.tar.gz" && \
-    tar -xvf ./dagger_${DAGGER_VERSION}_linux_amd64.tar.gz && mv dagger /bin && rm dagger_${DAGGER_VERSION}_linux_amd64.tar.gz && \
-    wget -O /tmp/otel-cli.apk https://github.com/equinix-labs/otel-cli/releases/download/v0.4.0/otel-cli_0.4.0_linux_amd64.apk && \
-    apk add --allow-untrusted /tmp/otel-cli.apk
+COPY --from=otel-cli /otel-cli /usr/bin/otel-cli
+COPY --from=dagger /bin/dagger /bin/dagger
 
 ADD . .
 RUN go build -o /src/grafana-build ./cmd


### PR DESCRIPTION
This simplifies how `otel-cli` is installed. It now grabs it from the upstream Docker image rather than a tarball, making it easier for Dependabot to track updates.

This also moves the dagger download/extraction into a separate stage for simplicity, but also to prepare for further simplification when https://github.com/dagger/dagger/issues/6887 is done.

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
