### PR TITLE
don't fail if no ght was found

### DIFF
--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -3,6 +3,7 @@ package arguments
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 	"path"
 	"path/filepath"
@@ -162,7 +163,7 @@ func grafanaDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, er
 
 	ght, err := o.githubToken(ctx)
 	if err != nil {
-		return nil, err
+		log.Println("No github token found:", err)
 	}
 
 	src, err := cloneOrMount(ctx, opts.Client, o.GrafanaDir, o.GrafanaRepo, o.GrafanaRef, ght)


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
