### PR TITLE
Add docker build to github actions PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,3 +34,10 @@ jobs:
           go-version: stable
           cache: true
       - run: "go test ./... -v"
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - run: "docker build ."


### PR DESCRIPTION
We didn't realize that the docker image for this wasn't being pushed until we ran into another bug. Once we fixed the Dockerfile it pushed up several weeks worth of changes which caused us to run into another bug.