### PR TITLE
Use `gitignore` to remove unneeded files/directories from build

### DIFF
--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/cliutil"

--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/cliutil"
@@ -119,9 +120,10 @@ func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, r
 		}
 		parsed := git.ParseGitignore(path, grafanaDir, string(gitignore))
 
-		grafanaDir = daggerutil.RemoveFilesAndDirs(grafanaDir, parsed.Exclude)
-		grafanaDir = daggerutil.AddFilesAndDirs(grafanaDir, parsed.Include)
-
+		grafanaDir = client.Host().Directory(path, dagger.HostDirectoryOpts{
+			Exclude: parsed.ExcludePaths,
+		})
+		grafanaDir = daggerutil.AddFilesAndDirs(path, client, grafanaDir, parsed.Include)
 		return grafanaDir, nil
 	}
 

--- a/daggerutil/directory.go
+++ b/daggerutil/directory.go
@@ -1,0 +1,34 @@
+package daggerutil
+
+import (
+	"log/slog"
+
+	"dagger.io/dagger"
+	"github.com/grafana/grafana-build/git"
+)
+
+func RemoveFilesAndDirs(src *dagger.Directory, paths git.Paths) *dagger.Directory {
+	for _, path := range paths.Files {
+		slog.Info("removing file from dagger directory", "path", path)
+		src = src.WithoutFile(path)
+	}
+	for _, path := range paths.Directories {
+		slog.Info("removing directory from dagger directory", "path", path)
+		src = src.WithoutDirectory(path)
+	}
+	return src
+}
+
+func AddFilesAndDirs(src *dagger.Directory, include git.Include) *dagger.Directory {
+	for path, file := range include.Files {
+		file := file
+		slog.Info("adding file to dagger directory", "path", path)
+		src = src.WithFile(path, &file)
+	}
+	for path, dir := range include.Directories {
+		dir := dir
+		slog.Info("adding directory to dagger directory", "path", path)
+		src = src.WithDirectory(path, &dir)
+	}
+	return src
+}

--- a/daggerutil/directory.go
+++ b/daggerutil/directory.go
@@ -19,16 +19,18 @@ func RemoveFilesAndDirs(src *dagger.Directory, paths git.Paths) *dagger.Director
 	return src
 }
 
-func AddFilesAndDirs(src *dagger.Directory, include git.Include) *dagger.Directory {
-	for path, file := range include.Files {
-		file := file
-		slog.Info("adding file to dagger directory", "path", path)
-		src = src.WithFile(path, &file)
+func AddFilesAndDirs(basePath string, client *dagger.Client, src *dagger.Directory, include git.Paths) *dagger.Directory {
+	for _, path := range include.Files {
+		filePath := basePath + path
+		file := client.Host().File(filePath)
+		slog.Info("adding file to dagger directory", "path", filePath)
+		src = src.WithFile(path, file)
 	}
-	for path, dir := range include.Directories {
-		dir := dir
-		slog.Info("adding directory to dagger directory", "path", path)
-		src = src.WithDirectory(path, &dir)
+	for _, path := range include.Directories {
+		dirPath := basePath + path
+		dir := client.Host().Directory(dirPath)
+		slog.Info("adding directory to dagger directory", "path", dirPath)
+		src = src.WithDirectory(path, dir)
 	}
 	return src
 }

--- a/git/gitignore.go
+++ b/git/gitignore.go
@@ -1,0 +1,107 @@
+package git
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+
+	"dagger.io/dagger"
+)
+
+type Paths struct {
+	Files       []string
+	Directories []string
+	Globs       []string
+}
+
+type Include struct {
+	Files       map[string]dagger.File
+	Directories map[string]dagger.Directory
+}
+type Gitignore struct {
+	Include Include
+	Exclude Paths
+}
+
+func IsDirectory(path string) (bool, bool, error) {
+	fileInfo, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+
+	return fileInfo.IsDir(), true, err
+}
+
+func DeterminePathType(path string, basePath string, paths *Paths) {
+	// This is essentially the same as specifying the directory without the /*
+	path = strings.TrimSuffix(path, "/*")
+	if strings.Contains(path, "*") {
+		slog.Info("found glob path", "path", path)
+		paths.Globs = append(paths.Globs, path)
+		return
+	}
+	cleanPath, _ := strings.CutPrefix(path, "/")
+	cleanPath = basePath + cleanPath
+	isDir, exists, err := IsDirectory(cleanPath)
+	if err != nil {
+		slog.Warn("failed to parse gitignore path", "path", cleanPath, "error", err)
+		return
+	}
+	if exists {
+		if isDir {
+			slog.Info("found directory path", "path", path)
+			paths.Directories = append(paths.Directories, path)
+		} else {
+			slog.Info("found file path", "path", path)
+			paths.Files = append(paths.Files, path)
+		}
+	}
+}
+
+func ParseGitignore(basePath string, daggerDir *dagger.Directory, contents string) Gitignore {
+	slog.Info("parsing gitignore contents")
+	gitignore := Gitignore{}
+	include := Paths{
+		Files:       []string{},
+		Directories: []string{},
+		Globs:       []string{},
+	}
+	exclude := Paths{
+		Files:       []string{},
+		Directories: []string{},
+		Globs:       []string{},
+	}
+	for _, line := range strings.Split(contents, "\n") {
+		if line != "" {
+			line = strings.TrimSpace(line)
+			// Ignore comments
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			if strings.HasPrefix(line, "!") {
+				DeterminePathType(strings.TrimPrefix(line, "!"), basePath, &include)
+			} else {
+				DeterminePathType(line, basePath, &exclude)
+			}
+		}
+	}
+
+	includeFiles := map[string]dagger.File{}
+	includeDirectories := map[string]dagger.Directory{}
+	for _, file := range include.Files {
+		includeFiles[file] = *daggerDir.File(file)
+	}
+	for _, dir := range include.Directories {
+		includeDirectories[dir] = *daggerDir.Directory(dir)
+	}
+
+	gitignore.Include.Files = includeFiles
+	gitignore.Include.Directories = includeDirectories
+	gitignore.Exclude = exclude
+	slog.Info("successfully parsed gitignore")
+	return gitignore
+}


### PR DESCRIPTION
At the moment if the `grafana-dir` argument is supplied, a local directory will be used without performing much filtering on the content of that directory. This leads to a fairly substantial amount of time to copy the directory to a container as the `grafana/grafana` project with dependencies installed can be in excess of 2GB.

This change will make use of the `gitignore` in the directory to determine what files/directories should be included or removed.

If the files/directories do not exist in the host directory they will be ignored by default.

Consider this a WIP for now. Atm `glob` patterns are ignored because they can be complex to parse correctly.