### PR TITLE
Upgrade default Go version to 1.22.3

### DIFF
--- a/arguments/golang.go
+++ b/arguments/golang.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	DefaultGoVersion      = "1.22.2"
+	DefaultGoVersion      = "1.22.3"
 	DefaultViceroyVersion = "v0.4.0"
 )
 


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
