### PR TITLE
Get the commit hash before patches are applied

### DIFF
--- a/arguments/grafana.go
+++ b/arguments/grafana.go
@@ -154,6 +154,15 @@ func grafanaDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, er
 		return nil, err
 	}
 
+	commitFile := opts.Client.Container().From("alpine/git").
+		WithWorkdir("/src").
+		WithMountedDirectory("/src/.git", src.Directory(".git")).
+		WithEntrypoint([]string{}).
+		WithExec([]string{"/bin/sh", "-c", "git rev-parse HEAD > .buildinfo.grafana-commit"}).
+		File("/src/.buildinfo.grafana-commit")
+
+	src = src.WithFile(".buildinfo.commit", commitFile)
+
 	if o.PatchesRepo != "" {
 		withPatches, err := applyPatches(ctx, opts.Client, src, o.PatchesRepo, o.PatchesPath, o.PatchesRef, ght)
 		if err != nil {

--- a/backend/build.go
+++ b/backend/build.go
@@ -54,7 +54,7 @@ func Build(
 	out string,
 	opts *BuildOpts,
 ) *dagger.Directory {
-	vcsinfo := GetVCSInfo(d, src, opts.Version, opts.Enterprise)
+	vcsinfo := GetVCSInfo(src, opts.Version, opts.Enterprise)
 	builder = WithVCSInfo(builder, vcsinfo, opts.Enterprise)
 
 	ldflags := LDFlagsDynamic(vcsinfo)

--- a/backend/builder.go
+++ b/backend/builder.go
@@ -149,7 +149,7 @@ func Builder(
 		return nil, err
 	}
 
-	commitInfo := GetVCSInfo(d, src, version, opts.Enterprise)
+	commitInfo := GetVCSInfo(src, version, opts.Enterprise)
 
 	builder = withCue(builder, src).
 		WithDirectory("/src/", src, dagger.ContainerWithDirectoryOpts{

--- a/backend/vcsinfo.go
+++ b/backend/vcsinfo.go
@@ -27,21 +27,15 @@ func WithVCSInfo(c *dagger.Container, info *VCSInfo, enterprise bool) *dagger.Co
 }
 
 // VCSInfo gets the VCS data from the directory 'src', writes them to a file on the given container, and returns the files which can be used in other containers.
-func GetVCSInfo(d *dagger.Client, src *dagger.Directory, version string, enterprise bool) *VCSInfo {
-	c := d.Container().From("alpine/git").
-		WithEntrypoint([]string{}).
-		WithMountedDirectory("/src", src).
-		WithWorkdir("/src").
-		WithExec([]string{"/bin/sh", "-c", "git rev-parse --abbrev-ref HEAD > .buildinfo.branch"})
-
+func GetVCSInfo(src *dagger.Directory, version string, enterprise bool) *VCSInfo {
 	info := &VCSInfo{
 		Version: version,
-		Commit:  c.File(".buildinfo.commit"),
-		Branch:  c.File(".buildinfo.branch"),
+		Commit:  src.File(".buildinfo.commit"),
+		Branch:  src.File(".buildinfo.branch"),
 	}
 
 	if enterprise {
-		info.EnterpriseCommit = c.File(".buildinfo.enterprise-commit")
+		info.EnterpriseCommit = src.File(".buildinfo.enterprise-commit")
 	}
 
 	return info

--- a/backend/vcsinfo.go
+++ b/backend/vcsinfo.go
@@ -32,7 +32,6 @@ func GetVCSInfo(d *dagger.Client, src *dagger.Directory, version string, enterpr
 		WithEntrypoint([]string{}).
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
-		WithExec([]string{"/bin/sh", "-c", "git rev-parse HEAD > .buildinfo.commit"}).
 		WithExec([]string{"/bin/sh", "-c", "git rev-parse --abbrev-ref HEAD > .buildinfo.branch"})
 
 	info := &VCSInfo{


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
