### PR TITLE
Move grafana-server init script to /etc/rc.d/init.d

### DIFF
--- a/artifacts/package_deb.go
+++ b/artifacts/package_deb.go
@@ -77,7 +77,6 @@ func (d *Deb) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		BeforeRemove: "/src/packaging/deb/control/prerm",
 		Depends: []string{
 			"adduser",
-			"libfontconfig1",
 			"musl",
 		},
 		EnvFolder: "/pkg/etc/default",

--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -91,8 +91,6 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		AfterInstall: "/src/packaging/rpm/control/postinst",
 		Depends: []string{
 			"/sbin/service",
-			"fontconfig",
-			"freetype",
 		},
 		ExtraArgs: []string{
 			"--rpm-posttrans=/src/packaging/rpm/control/posttrans",

--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -85,7 +85,7 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		NameOverride: d.NameOverride,
 		ConfigFiles: [][]string{
 			{"/src/packaging/rpm/sysconfig/grafana-server", "/pkg/etc/sysconfig/grafana-server"},
-			{"/src/packaging/rpm/init.d/grafana-server", "/pkg/etc/init.d/grafana-server"},
+			{"/src/packaging/rpm/init.d/grafana-server", "/pkg/etc/rc.d/init.d/grafana-server"},
 			{"/src/packaging/rpm/systemd/grafana-server.service", "/pkg/usr/lib/systemd/system/grafana-server.service"},
 		},
 		AfterInstall: "/src/packaging/rpm/control/postinst",

--- a/fpm/build.go
+++ b/fpm/build.go
@@ -104,9 +104,6 @@ func Build(builder *dagger.Container, opts BuildOpts, targz *dagger.File) *dagge
 		packagePaths = []string{
 			"/pkg/usr/sbin",
 			"/pkg/usr/share",
-			// init.d scripts are service management scripts that start/stop/restart/enable the grafana service without systemd.
-			// these are likely to be deprecated as systemd is now the default pretty much everywhere.
-			"/pkg/etc/init.d",
 			// holds default environment variables for the grafana-server service
 			opts.EnvFolder,
 			// /etc/grafana is empty in the installation, but is set up by the postinstall script and must be created first.
@@ -115,6 +112,14 @@ func Build(builder *dagger.Container, opts BuildOpts, targz *dagger.File) *dagge
 			"/pkg/usr/lib/systemd/system",
 		}
 	)
+
+	// init.d scripts are service management scripts that start/stop/restart/enable the grafana service without systemd.
+	// these are likely to be deprecated as systemd is now the default pretty much everywhere.
+	if opts.PackageType == PackageTypeRPM {
+		packagePaths = append(packagePaths, "/pkg/etc/rc.d/init.d")
+	} else {
+		packagePaths = append(packagePaths, "/pkg/etc/init.d")
+	}
 
 	container := builder.
 		WithFile("/src/grafana.tar.gz", targz).


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).

Based on our investigation (with @evictorero ), these dependencies are not needed for the image rendering or reporting features of Grafana Enterprise.