### PR TITLE
adds latest flag to nightly push script for grafana-enterprise-dev

### DIFF
--- a/scripts/drone_publish_nightly_enterprise.sh
+++ b/scripts/drone_publish_nightly_enterprise.sh
@@ -7,6 +7,7 @@ dagger run --silent go run ./cmd docker publish \
   $(find $local_dir | grep docker.tar.gz | grep -v sha256 | awk '{print "--package=file://"$0}') \
   --username=${DOCKER_USERNAME} \
   --password=${DOCKER_PASSWORD} \
+  --latest \
   --repo="grafana-enterprise-dev"
 
 # Publish packages to the downloads bucket


### PR DESCRIPTION
Currently we are not tagging the nightly docker image for `grafana-enterprise-dev`, and using them for development requires finding the latest tag.

This change would auto-tag the image pushed nightly as latest, allowing dev environments to always pull the latest build.

[Docker Tags](https://hub.docker.com/repository/docker/grafana/grafana-enterprise-dev/tags
)

NOTE: The option exists in code to tag, but I haven't tested it yet.

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
