### PR TITLE
Ignore node modules when packaging the tar.gz

### DIFF
--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -92,7 +92,6 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		Depends: []string{
 			"/sbin/service",
 			"fontconfig",
-			"freetype",
 		},
 		ExtraArgs: []string{
 			"--rpm-posttrans=/src/packaging/rpm/control/posttrans",

--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -92,6 +92,7 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		Depends: []string{
 			"/sbin/service",
 			"fontconfig",
+			"freetype",
 		},
 		ExtraArgs: []string{
 			"--rpm-posttrans=/src/packaging/rpm/control/posttrans",

--- a/artifacts/package_targz.go
+++ b/artifacts/package_targz.go
@@ -262,7 +262,9 @@ func (t *Tarball) BuildFile(ctx context.Context, b *dagger.Container, opts *pipe
 		targz.NewMappedDir("packaging/docker", grafanaDir.Directory("packaging/docker")),
 		targz.NewMappedDir("packaging/wrappers", grafanaDir.Directory("packaging/wrappers")),
 		targz.NewMappedDir("bin", backendDir),
-		targz.NewMappedDir("public", frontendDir),
+		targz.NewMappedDir("public", frontendDir, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"node_modules", "**/*/node_modules"},
+		}),
 		targz.NewMappedDir("npm-artifacts", npmDir),
 		targz.NewMappedDir("storybook", storybookDir),
 		targz.NewMappedDir("plugins-bundled", pluginsDir),

--- a/artifacts/package_targz.go
+++ b/artifacts/package_targz.go
@@ -263,11 +263,13 @@ func (t *Tarball) BuildFile(ctx context.Context, b *dagger.Container, opts *pipe
 		targz.NewMappedDir("packaging/wrappers", grafanaDir.Directory("packaging/wrappers")),
 		targz.NewMappedDir("bin", backendDir),
 		targz.NewMappedDir("public", frontendDir, dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules", "**/*/node_modules"},
+			Exclude: []string{"node_modules", "*/node_modules", "**/*/node_modules"},
 		}),
 		targz.NewMappedDir("npm-artifacts", npmDir),
 		targz.NewMappedDir("storybook", storybookDir),
-		targz.NewMappedDir("plugins-bundled", pluginsDir),
+		targz.NewMappedDir("plugins-bundled", pluginsDir, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"node_modules", "*/node_modules", "**/*/node_modules"},
+		}),
 	}
 
 	root := fmt.Sprintf("grafana-%s", version)

--- a/targz/build.go
+++ b/targz/build.go
@@ -6,13 +6,14 @@ import (
 	"dagger.io/dagger"
 )
 
-func NewMappedDir(path string, directory *dagger.Directory) MappedDirectory {
-	return MappedDirectory{path: path, directory: directory}
+func NewMappedDir(path string, directory *dagger.Directory, opts ...dagger.ContainerWithDirectoryOpts) MappedDirectory {
+	return MappedDirectory{path: path, directory: directory, opts: opts}
 }
 
 type MappedDirectory struct {
 	path      string
 	directory *dagger.Directory
+	opts      []dagger.ContainerWithDirectoryOpts
 }
 
 type MappedFile struct {
@@ -51,7 +52,7 @@ func Build(packager *dagger.Container, opts *Opts) *dagger.File {
 
 	for _, v := range opts.Directories {
 		path := path.Join(root, v.path)
-		packager = packager.WithMountedDirectory(path, v.directory)
+		packager = packager.WithDirectory(path, v.directory, v.opts...)
 		paths = append(paths, path)
 	}
 


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
