### PR TITLE
Use mounted directories and remove node modules instead of using `Directory`

### DIFF
--- a/artifacts/package_targz.go
+++ b/artifacts/package_targz.go
@@ -262,14 +262,10 @@ func (t *Tarball) BuildFile(ctx context.Context, b *dagger.Container, opts *pipe
 		targz.NewMappedDir("packaging/docker", grafanaDir.Directory("packaging/docker")),
 		targz.NewMappedDir("packaging/wrappers", grafanaDir.Directory("packaging/wrappers")),
 		targz.NewMappedDir("bin", backendDir),
-		targz.NewMappedDir("public", frontendDir, dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules", "*/node_modules", "**/*/node_modules"},
-		}),
+		targz.NewMappedDir("public", frontendDir),
 		targz.NewMappedDir("npm-artifacts", npmDir),
 		targz.NewMappedDir("storybook", storybookDir),
-		targz.NewMappedDir("plugins-bundled", pluginsDir, dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules", "*/node_modules", "**/*/node_modules"},
-		}),
+		targz.NewMappedDir("plugins-bundled", pluginsDir),
 	}
 
 	root := fmt.Sprintf("grafana-%s", version)

--- a/frontend/build.go
+++ b/frontend/build.go
@@ -7,6 +7,7 @@ import (
 func Build(builder *dagger.Container) *dagger.Directory {
 	public := builder.
 		WithExec([]string{"yarn", "run", "build"}).
+		WithExec([]string{"/bin/sh", "-c", "find /src/public -type d -name node_modules -print0 | xargs -0 rm -rf"}).
 		Directory("/src/public")
 
 	return public
@@ -16,6 +17,7 @@ func BuildPlugins(builder *dagger.Container) *dagger.Directory {
 	public := builder.
 		WithExec([]string{"yarn", "install", "--immutable"}).
 		WithExec([]string{"yarn", "run", "plugins:build-bundled"}).
+		WithExec([]string{"/bin/sh", "-c", "find /src/plugins-bundled -type d -name node_modules -print0 | xargs -0 rm -rf"}).
 		Directory("/src/plugins-bundled")
 
 	return public

--- a/targz/build.go
+++ b/targz/build.go
@@ -6,14 +6,13 @@ import (
 	"dagger.io/dagger"
 )
 
-func NewMappedDir(path string, directory *dagger.Directory, opts ...dagger.ContainerWithDirectoryOpts) MappedDirectory {
-	return MappedDirectory{path: path, directory: directory, opts: opts}
+func NewMappedDir(path string, directory *dagger.Directory) MappedDirectory {
+	return MappedDirectory{path: path, directory: directory}
 }
 
 type MappedDirectory struct {
 	path      string
 	directory *dagger.Directory
-	opts      []dagger.ContainerWithDirectoryOpts
 }
 
 type MappedFile struct {
@@ -52,7 +51,7 @@ func Build(packager *dagger.Container, opts *Opts) *dagger.File {
 
 	for _, v := range opts.Directories {
 		path := path.Join(root, v.path)
-		packager = packager.WithDirectory(path, v.directory, v.opts...)
+		packager = packager.WithMountedDirectory(path, v.directory)
 		paths = append(paths, path)
 	}
 


### PR DESCRIPTION
This reverts https://github.com/grafana/grafana-build/pull/349/files

and adds `WithExec([]string{"/bin/sh", "-c", "find /src/public -type d -name node_modules -print0 | xargs -0 rm -rf`)

after we build the frontend, and the same for the builtin plugins.

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [x] I have tested this against `main` in Grafana.
* [x] I have tested this against `main` in Grafana Enterprise.
* [x] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [x] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
