### PR TITLE
chore: Bump Go to 1.23.0 & Alpine to 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/equinix-labs/otel-cli:v0.4.5 as otel-cli
 
-FROM alpine:3.19 AS dagger
+FROM alpine:3.20 AS dagger
 
 # TODO: pull the binary from registry.dagger.io/cli:v0.9.8 (or similar) when
 # https://github.com/dagger/dagger/issues/6887 is resolved
@@ -9,7 +9,7 @@ ADD https://github.com/dagger/dagger/releases/download/${DAGGER_VERSION}/dagger_
 RUN tar zxf /tmp/dagger_${DAGGER_VERSION}_linux_amd64.tar.gz -C /tmp
 RUN mv /tmp/dagger /bin/dagger
 
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 ARG DAGGER_VERSION=v0.11.6
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-build
 
-go 1.21
+go 1.23.0
 
 require (
 	dagger.io/dagger v0.11.6


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
