### PR TITLE
chore: upgrade to go 1.23.0

### DIFF
--- a/arguments/golang.go
+++ b/arguments/golang.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	DefaultGoVersion      = "1.22.5"
+	DefaultGoVersion      = "1.23.0"
 	DefaultViceroyVersion = "v0.4.0"
 )
 


### PR DESCRIPTION
The RRC patch builds are [failing](https://drone.grafana.net/grafana/grafana-enterprise/75788/4/3) due to the mismatch in version:

```
Stderr:
go: go.work requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
```