### PR TITLE
Chore: Add support for apps

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -156,6 +156,7 @@ func Builder(
 			Include: []string{"**/*.mod", "**/*.sum", "**/*.work"},
 		}).
 		WithDirectory("/src/pkg", src.Directory("pkg")).
+		WithDirectory("/src/apps", src.Directory("apps")).
 		WithDirectory("/src/emails", src.Directory("emails")).
 		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag)).
 		WithFile("/src/.buildinfo.commit", commitInfo.Commit).
@@ -181,6 +182,7 @@ func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goV
 			Include: []string{"**/*.mod", "**/*.sum", "**/*.work"},
 		}).
 		WithDirectory("/src/pkg", src.Directory("pkg")).
+		WithDirectory("/src/apps", src.Directory("apps")).
 		WithDirectory("/src/.bingo", src.Directory(".bingo")).
 		WithFile("/src/Makefile", src.File("Makefile")).
 		WithWorkdir("/src").

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -20,6 +20,7 @@ func Builder(d *dagger.Client, platform dagger.Platform, src *dagger.Directory, 
 				WithoutDirectory(".github").
 				WithoutDirectory("docs").
 				WithoutDirectory("pkg").
+				WithoutDirectory("apps").
 				WithoutDirectory(".nx"),
 			dagger.ContainerWithDirectoryOpts{
 				Exclude: []string{


### PR DESCRIPTION
This adds support for `apps/`, which is needed by https://github.com/grafana/grafana/pull/93246

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
