### PR TITLE
Add new docker-enterprise artifact

### DIFF
--- a/arguments/docker.go
+++ b/arguments/docker.go
@@ -58,10 +58,27 @@ var (
 		Usage: "Overrides the docker repository of the built images",
 		Value: "grafana-pro",
 	}
-	ProTagFormatFlag = &cli.StringFlag{
-		Name:  "pro-tag-format",
-		Usage: "Provide a go template for formatting the docker tag(s) for Grafana Pro images",
-		Value: docker.DefaultProTagFormat,
+
+	EntDockerRegistryFlag = &cli.StringFlag{
+		Name:  "enterprise-registry",
+		Usage: "Prefix the image name with the registry provided",
+		Value: "docker.io",
+	}
+	EntDockerOrgFlag = &cli.StringFlag{
+		Name:  "enterprise-org",
+		Usage: "Overrides the organization of the images",
+		Value: "grafana",
+	}
+	EntDockerRepoFlag = &cli.StringFlag{
+		Name:  "enterprise-repo",
+		Usage: "Overrides the docker repository of the built images",
+		Value: "grafana-enterprise",
+	}
+
+	HGTagFormatFlag = &cli.StringFlag{
+		Name:  "hg-tag-format",
+		Usage: "Provide a go template for formatting the docker tag(s) for Hosted Grafana images",
+		Value: docker.DefaultHGTagFormat,
 	}
 
 	DockerRegistry  = pipeline.NewStringFlagArgument(DockerRegistryFlag)
@@ -76,5 +93,10 @@ var (
 	ProDockerRegistry = pipeline.NewStringFlagArgument(ProDockerRegistryFlag)
 	ProDockerOrg      = pipeline.NewStringFlagArgument(ProDockerOrgFlag)
 	ProDockerRepo     = pipeline.NewStringFlagArgument(ProDockerRepoFlag)
-	ProTagFormat      = pipeline.NewStringFlagArgument(ProTagFormatFlag)
+
+	EntDockerRegistry = pipeline.NewStringFlagArgument(EntDockerRegistryFlag)
+	EntDockerOrg      = pipeline.NewStringFlagArgument(EntDockerOrgFlag)
+	EntDockerRepo     = pipeline.NewStringFlagArgument(EntDockerRepoFlag)
+
+	HGTagFormat = pipeline.NewStringFlagArgument(HGTagFormatFlag)
 )

--- a/arguments/hg_docker.go
+++ b/arguments/hg_docker.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var ProDirectoryFlags = []cli.Flag{
+var HGDirectoryFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "hosted-grafana-dir",
 		Usage:    "Local clone of HG to use, instead of git cloning",
@@ -29,24 +29,24 @@ var ProDirectoryFlags = []cli.Flag{
 	},
 }
 
-// ProDirectory will provide the valueFunc that initializes and returns a *dagger.Directory that has a repository that has the Grafana Pro docker image.
+// HGDirectory will provide the valueFunc that initializes and returns a *dagger.Directory that has a repository that has the Grafana Pro/Enterprise docker image.
 // Where possible, when cloning and no authentication options are provided, the valuefunc will try to use the configured github CLI for cloning.
-var ProDirectory = pipeline.Argument{
-	Name:        "pro-dir",
-	Description: "The source tree of that has the Dockerfile for Grafana Pro",
-	Flags:       ProDirectoryFlags,
-	ValueFunc:   proDirectory,
+var HGDirectory = pipeline.Argument{
+	Name:        "hg-dir",
+	Description: "The source tree of that has the Dockerfile for Grafana Pro/Enterprise",
+	Flags:       HGDirectoryFlags,
+	ValueFunc:   hgDirectory,
 }
 
-type ProDirectoryOpts struct {
+type HGDirectoryOpts struct {
 	GitHubToken string
 	HGDir       string
 	HGRepo      string
 	HGRef       string
 }
 
-func ProDirectoryOptsFromFlags(c cliutil.CLIContext) *ProDirectoryOpts {
-	return &ProDirectoryOpts{
+func HGDirectoryOptsFromFlags(c cliutil.CLIContext) *HGDirectoryOpts {
+	return &HGDirectoryOpts{
 		GitHubToken: c.String("github-token"),
 		HGDir:       c.String("hosted-grafana-dir"),
 		HGRepo:      c.String("hosted-grafana-repo"),
@@ -54,8 +54,8 @@ func ProDirectoryOptsFromFlags(c cliutil.CLIContext) *ProDirectoryOpts {
 	}
 }
 
-func proDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, error) {
-	o := ProDirectoryOptsFromFlags(opts.CLIContext)
+func hgDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, error) {
+	o := HGDirectoryOptsFromFlags(opts.CLIContext)
 	ght, err := githubToken(ctx, o.GitHubToken)
 	if err != nil {
 		return nil, fmt.Errorf("could not get GitHub token: %w", err)

--- a/artifacts/package_docker_enterprise.go
+++ b/artifacts/package_docker_enterprise.go
@@ -16,55 +16,54 @@ import (
 )
 
 var (
-	ProDockerArguments = arguments.Join(
+	EntDockerArguments = arguments.Join(
 		DebArguments,
 		[]pipeline.Argument{
 			arguments.HGDirectory,
-			arguments.ProDockerRegistry,
-			arguments.ProDockerOrg,
-			arguments.ProDockerRepo,
+			arguments.EntDockerRegistry,
+			arguments.EntDockerOrg,
+			arguments.EntDockerRepo,
 			arguments.HGTagFormat,
 		},
 	)
-	ProDockerFlags = flags.JoinFlags(
+	EntDockerFlags = flags.JoinFlags(
 		DebFlags,
 		flags.DockerFlags,
 	)
 )
 
-var ProDockerInitializer = Initializer{
-	InitializerFunc: NewProDockerFromString,
-	Arguments:       ProDockerArguments,
+var EntDockerInitializer = Initializer{
+	InitializerFunc: NewEntDockerFromString,
+	Arguments:       EntDockerArguments,
 }
 
-// ProDocker uses a built deb installer to create a docker image
-type ProDocker struct {
+// EntDocker uses a built deb installer to create a docker image
+type EntDocker struct {
 	Name    packages.Name
 	Version string
 	BuildID string
 	Distro  backend.Distribution
-	ProDir  *dagger.Directory
+	EntDir  *dagger.Directory
 
-	// ProRegistry is the docker registry when using the `pro` name. (e.g. hub.docker.io)
-	ProRegistry string
-	// ProOrg is the docker org when using the `pro` name. (e.g. grafana)
-	ProOrg string
-	// ProOrg is the docker repo when using the `pro` name. (e.g. grafana-pro)
-	ProRepo string
-	// TagFormat is the docker tag format when using the `pro` name. (e.g. {{ .version }}-{{ .os }}-{{ .arch }})
+	// EntRegistry is the docker registry when using the `enterprise` name. (e.g. hub.docker.io)
+	EntRegistry string
+	// EntOrg is the docker org when using the `enterprise` name. (e.g. grafana)
+	EntOrg string
+	// EntOrg is the docker repo when using the `enterprise` name. (e.g. grafana-enterprise)
+	EntRepo string
+	// TagFormat is the docker tag format when using the `enterprise` name. (e.g. {{ .version }}-{{ .os }}-{{ .arch }})
 	TagFormat string
 
-	// Building the Pro image requires a Debian package instead of a tar.gz
 	Deb *pipeline.Artifact
 }
 
-func (d *ProDocker) Dependencies(ctx context.Context) ([]*pipeline.Artifact, error) {
+func (d *EntDocker) Dependencies(ctx context.Context) ([]*pipeline.Artifact, error) {
 	return []*pipeline.Artifact{
 		d.Deb,
 	}, nil
 }
 
-func (d *ProDocker) Builder(ctx context.Context, opts *pipeline.ArtifactContainerOpts) (*dagger.Container, error) {
+func (d *EntDocker) Builder(ctx context.Context, opts *pipeline.ArtifactContainerOpts) (*dagger.Container, error) {
 	deb, err := opts.Store.File(ctx, d.Deb)
 	if err != nil {
 		return nil, fmt.Errorf("error getting deb from state: %w", err)
@@ -74,13 +73,13 @@ func (d *ProDocker) Builder(ctx context.Context, opts *pipeline.ArtifactContaine
 
 	return opts.Client.Container().From("docker").
 		WithUnixSocket("/var/run/docker.sock", socket).
-		WithMountedDirectory("/src", d.ProDir).
+		WithMountedDirectory("/src", d.EntDir).
 		WithMountedFile("/src/grafana.deb", deb).
 		WithWorkdir("/src"), nil
 }
 
-func (d *ProDocker) BuildFile(ctx context.Context, builder *dagger.Container, opts *pipeline.ArtifactContainerOpts) (*dagger.File, error) {
-	tags, err := docker.Tags(d.ProOrg, d.ProRegistry, []string{d.ProRepo}, d.TagFormat, packages.NameOpts{
+func (d *EntDocker) BuildFile(ctx context.Context, builder *dagger.Container, opts *pipeline.ArtifactContainerOpts) (*dagger.File, error) {
+	tags, err := docker.Tags(d.EntOrg, d.EntRegistry, []string{d.EntRepo}, d.TagFormat, packages.NameOpts{
 		Name:    d.Name,
 		Version: d.Version,
 		BuildID: d.BuildID,
@@ -94,7 +93,7 @@ func (d *ProDocker) BuildFile(ctx context.Context, builder *dagger.Container, op
 	builder = docker.Build(opts.Client, builder, &docker.BuildOpts{
 		Dockerfile: "./docker/hosted-grafana-all/Dockerfile",
 		Tags:       tags,
-		Target:     "hosted-grafana-pro",
+		Target:     "hosted-grafana-enterprise",
 		Platform:   dagger.Platform("linux/amd64"),
 		BuildArgs: []string{
 			"RELEASE_TYPE=main",
@@ -104,22 +103,22 @@ func (d *ProDocker) BuildFile(ctx context.Context, builder *dagger.Container, op
 	})
 
 	// Save the resulting docker image to the local filesystem
-	return builder.WithExec([]string{"docker", "save", tags[0], "-o", "pro.tar"}).File("pro.tar"), nil
+	return builder.WithExec([]string{"docker", "save", tags[0], "-o", "enterprise.tar"}).File("enterprise.tar"), nil
 }
 
-func (d *ProDocker) BuildDir(ctx context.Context, builder *dagger.Container, opts *pipeline.ArtifactContainerOpts) (*dagger.Directory, error) {
+func (d *EntDocker) BuildDir(ctx context.Context, builder *dagger.Container, opts *pipeline.ArtifactContainerOpts) (*dagger.Directory, error) {
 	panic("This artifact does not produce directories")
 }
 
-func (d *ProDocker) Publisher(ctx context.Context, opts *pipeline.ArtifactContainerOpts) (*dagger.Container, error) {
+func (d *EntDocker) Publisher(ctx context.Context, opts *pipeline.ArtifactContainerOpts) (*dagger.Container, error) {
 	panic("not implemented")
 }
 
-func (d *ProDocker) PublishFile(ctx context.Context, opts *pipeline.ArtifactPublishFileOpts) error {
+func (d *EntDocker) PublishFile(ctx context.Context, opts *pipeline.ArtifactPublishFileOpts) error {
 	panic("not implemented")
 }
 
-func (d *ProDocker) PublishDir(ctx context.Context, opts *pipeline.ArtifactPublishDirOpts) error {
+func (d *EntDocker) PublishDir(ctx context.Context, opts *pipeline.ArtifactPublishDirOpts) error {
 	panic("This artifact does not produce directories")
 }
 
@@ -128,21 +127,21 @@ func (d *ProDocker) PublishDir(ctx context.Context, opts *pipeline.ArtifactPubli
 // also affect the filename to ensure that there are no collisions.
 // For example, the backend for `linux/amd64` and `linux/arm64` should not both produce a `bin` folder, they should produce a
 // `bin/linux-amd64` folder and a `bin/linux-arm64` folder. Callers can mount this as `bin` or whatever if they want.
-func (d *ProDocker) Filename(ctx context.Context) (string, error) {
-	ext := "docker-pro.tar.gz"
+func (d *EntDocker) Filename(ctx context.Context) (string, error) {
+	ext := "docker-enterprise.tar.gz"
 
 	return packages.FileName(d.Name, d.Version, d.BuildID, d.Distro, ext)
 }
 
-func (d *ProDocker) VerifyFile(ctx context.Context, client *dagger.Client, file *dagger.File) error {
+func (d *EntDocker) VerifyFile(ctx context.Context, client *dagger.Client, file *dagger.File) error {
 	return nil
 }
 
-func (d *ProDocker) VerifyDirectory(ctx context.Context, client *dagger.Client, dir *dagger.Directory) error {
+func (d *EntDocker) VerifyDirectory(ctx context.Context, client *dagger.Client, dir *dagger.Directory) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func NewProDockerFromString(ctx context.Context, log *slog.Logger, artifact string, state pipeline.StateHandler) (*pipeline.Artifact, error) {
+func NewEntDockerFromString(ctx context.Context, log *slog.Logger, artifact string, state pipeline.StateHandler) (*pipeline.Artifact, error) {
 	options, err := pipeline.ParseFlags(artifact, DockerFlags)
 	if err != nil {
 		return nil, err
@@ -158,15 +157,15 @@ func NewProDockerFromString(ctx context.Context, log *slog.Logger, artifact stri
 		return nil, err
 	}
 
-	proRegistry, err := state.String(ctx, arguments.ProDockerRegistry)
+	entRegistry, err := state.String(ctx, arguments.EntDockerRegistry)
 	if err != nil {
 		return nil, err
 	}
-	proOrg, err := state.String(ctx, arguments.ProDockerOrg)
+	entOrg, err := state.String(ctx, arguments.EntDockerOrg)
 	if err != nil {
 		return nil, err
 	}
-	proRepo, err := state.String(ctx, arguments.ProDockerRepo)
+	entRepo, err := state.String(ctx, arguments.EntDockerRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -180,21 +179,21 @@ func NewProDockerFromString(ctx context.Context, log *slog.Logger, artifact stri
 		return nil, err
 	}
 
-	log.Info("initializing Pro Docker artifact", "Org", proOrg, "registry", proRegistry, "repo", proRepo, "tag", tagFormat)
+	log.Info("initializing Enterprise Docker artifact", "Org", entOrg, "registry", entRegistry, "repo", entRepo, "tag", tagFormat)
 
 	return pipeline.ArtifactWithLogging(ctx, log, &pipeline.Artifact{
 		ArtifactString: artifact,
-		Handler: &ProDocker{
+		Handler: &EntDocker{
 			Name:    p.Name,
 			Version: p.Version,
 			BuildID: p.BuildID,
 			Distro:  p.Distribution,
-			ProDir:  dir,
+			EntDir:  dir,
 			Deb:     deb,
 
-			ProRegistry: proRegistry,
-			ProOrg:      proOrg,
-			ProRepo:     proRepo,
+			EntRegistry: entRegistry,
+			EntOrg:      entOrg,
+			EntRepo:     entRepo,
 			TagFormat:   tagFormat,
 		},
 		Type:  pipeline.ArtifactTypeFile,

--- a/artifacts/package_docker_enterprise.go
+++ b/artifacts/package_docker_enterprise.go
@@ -93,7 +93,7 @@ func (d *EntDocker) BuildFile(ctx context.Context, builder *dagger.Container, op
 	builder = docker.Build(opts.Client, builder, &docker.BuildOpts{
 		Dockerfile: "./docker/hosted-grafana-all/Dockerfile",
 		Tags:       tags,
-		Target:     "hosted-grafana-enterprise",
+		Target:     "hosted-grafana-localenterprise",
 		Platform:   dagger.Platform("linux/amd64"),
 		BuildArgs: []string{
 			"RELEASE_TYPE=main",

--- a/artifacts/package_docker_pro.go
+++ b/artifacts/package_docker_pro.go
@@ -94,7 +94,7 @@ func (d *ProDocker) BuildFile(ctx context.Context, builder *dagger.Container, op
 	builder = docker.Build(opts.Client, builder, &docker.BuildOpts{
 		Dockerfile: "./docker/hosted-grafana-all/Dockerfile",
 		Tags:       tags,
-		Target:     "hosted-grafana-pro",
+		Target:     "hosted-grafana-localpro",
 		Platform:   dagger.Platform("linux/amd64"),
 		BuildArgs: []string{
 			"RELEASE_TYPE=main",

--- a/cmd/artifacts.go
+++ b/cmd/artifacts.go
@@ -5,15 +5,16 @@ import (
 )
 
 var Artifacts = map[string]artifacts.Initializer{
-	"backend":    artifacts.BackendInitializer,
-	"frontend":   artifacts.FrontendInitializer,
-	"npm":        artifacts.NPMPackagesInitializer,
-	"targz":      artifacts.TargzInitializer,
-	"zip":        artifacts.ZipInitializer,
-	"deb":        artifacts.DebInitializer,
-	"rpm":        artifacts.RPMInitializer,
-	"docker":     artifacts.DockerInitializer,
-	"docker-pro": artifacts.ProDockerInitializer,
-	"storybook":  artifacts.StorybookInitializer,
-	"exe":        artifacts.ExeInitializer,
+	"backend":           artifacts.BackendInitializer,
+	"frontend":          artifacts.FrontendInitializer,
+	"npm":               artifacts.NPMPackagesInitializer,
+	"targz":             artifacts.TargzInitializer,
+	"zip":               artifacts.ZipInitializer,
+	"deb":               artifacts.DebInitializer,
+	"rpm":               artifacts.RPMInitializer,
+	"docker":            artifacts.DockerInitializer,
+	"docker-pro":        artifacts.ProDockerInitializer,
+	"docker-enterprise": artifacts.EntDockerInitializer,
+	"storybook":         artifacts.StorybookInitializer,
+	"exe":               artifacts.ExeInitializer,
 }

--- a/docker/build.go
+++ b/docker/build.go
@@ -18,6 +18,8 @@ type BuildOpts struct {
 	Tags []string
 	// BuildArgs are provided to the docker command as '--build-arg'
 	BuildArgs []string
+	// Set the target build stage to build as '--target'
+	Target string
 
 	// Platform, if set to the non-default value, will use buildkit's emulation to build the docker image. This can be useful if building a docker image for a platform that doesn't match the host platform.
 	Platform dagger.Platform
@@ -53,6 +55,10 @@ func Build(d *dagger.Client, builder *dagger.Container, opts *BuildOpts) *dagger
 
 	for _, v := range opts.Tags {
 		args = append(args, "-t", v)
+	}
+
+	if opts.Target != "" {
+		args = append(args, "--target", opts.Target)
 	}
 
 	return builder.WithExec(args)

--- a/docker/tags.go
+++ b/docker/tags.go
@@ -21,7 +21,7 @@ const (
 	DefaultTagFormat       = "{{ .version }}-{{ .arch }}"
 	DefaultUbuntuTagFormat = "{{ .version }}-ubuntu-{{ .arch }}"
 	DefaultBoringTagFormat = "{{ .version }}-{{ .arch }}-boringcrypto"
-	DefaultProTagFormat    = "{{ .version }}-{{ .arch }}"
+	DefaultHGTagFormat     = "{{ .version }}-{{ .arch }}"
 )
 
 // Tags returns the name of the grafana docker image based on the tar package name.


### PR DESCRIPTION
Related with https://github.com/grafana/hosted-grafana/issues/5817

We need a docker-enterprise artifact to build the hosted-grafana-enterprise image.
These artifacts are only used for rrc patching atm.

Added the --target option to the docker build, and set it accordingly in both ProDocker and EntDocker

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
