### PR TITLE
Chore: Add Grafana version test coverage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
 # Requirements
 
-The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.
+The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**. To
+run integration tests, add a comment to this PR with the following:
 
-* [ ] I have tested this against `main` in Grafana.
-* [ ] I have tested this against `main` in Grafana Enterprise.
-* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
-* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
+```
+/grafana-integration-tests
+```
+
+* [ ] I have added the `/grafana-integration-tests` comment to this PR
+* [ ] All integration tests have passed
+

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,28 @@
+name: PR Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  grafana-integration-test:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/grafana-integration-test' }}
+    strategy:
+      matrix:
+        version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout grafana
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/grafana
+          ref: ${{ matrix.version }}
+          path: grafana
+      - uses: dagger/dagger-for-github@v6
+        with:
+          verb: run
+          args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.issue.pull_request, '/grafana-integration-tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout grafana

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,13 +1,13 @@
 name: PR Integration tests
 
 on:
+  pull_request: {}
   issue_comment:
     types: [created]
 
 jobs:
   grafana-integration-test:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/grafana-integration-test' }}
     strategy:
       matrix:
         version: [main]
@@ -15,6 +15,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.issue.pull_request, '/grafana-integration-tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout grafana

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -23,8 +23,24 @@ jobs:
           repository: grafana/grafana
           ref: ${{ matrix.version }}
           path: grafana
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
+      - name: Clean runner
+        run: |
+          df -h
+          docker builder prune -f
+          docker system prune -a -f
+          sudo rm -rf /opt/google/chrome
+          sudo rm -rf /opt/microsoft/msedge
+          sudo rm -rf /opt/microsoft/powershell
+          sudo rm -rf /opt/pipx
+          sudo rm -rf /usr/lib/mono
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          df -h
       - uses: dagger/dagger-for-github@v6
         with:
           verb: run

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [main]
-        #version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
+        version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,4 +1,4 @@
-name: PR Comment
+name: PR Integration tests
 
 on:
   issue_comment:
@@ -10,7 +10,8 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/grafana-integration-test' }}
     strategy:
       matrix:
-        version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
+        version: [main]
+        #version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -27,6 +27,7 @@ jobs:
         if: matrix.type == 'enterprise'
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: grafana/grafana-enterprise
           ref: ${{ matrix.version }}
           path: grafana-enterprise

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       matrix:
         version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
-        type: [oss, enterprise]
+        type: [oss]
+        # TODO: figure out enterprise auth 
+        # type: [oss, enterprise]
     permissions:
       id-token: write
       contents: read
@@ -49,15 +51,17 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
           df -h
+      - name: Get Grafana golang version
+        run: echo "GRAFANA_GO_VERSION=$(grep "go 1." grafana/go.work |  cut -d\  -f2)" >> "$GITHUB_ENV"
       - name: OSS tests
         uses: dagger/dagger-for-github@v6
         if: matrix.type == 'oss'
         with:
           verb: run
-          args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana
+          args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana --go-version=${GRAFANA_GO_VERSION}
       - name: Enterprise tests
         uses: dagger/dagger-for-github@v6
         if: matrix.type == 'enterprise'
         with:
           verb: run
-          args: go run ./cmd artifacts -a targz:grafana-enterprise:linux/amd64 --grafana-dir=grafana --enterprise-dir=grafana-enterprise
+          args: go run ./cmd artifacts -a targz:grafana-enterprise:linux/amd64 --grafana-dir=grafana --enterprise-dir=grafana-enterprise --go-version=${GRAFANA_GO_VERSION}

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -23,6 +23,8 @@ jobs:
           repository: grafana/grafana
           ref: ${{ matrix.version }}
           path: grafana
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       - uses: dagger/dagger-for-github@v6
         with:
           verb: run

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,13 +1,13 @@
-name: PR Integration tests
+name: PR Integration Tests
 
 on:
-  pull_request: {}
   issue_comment:
     types: [created]
 
 jobs:
-  grafana-integration-test:
+  grafana-integration-tests:
     runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/grafana-integration-tests' }}
     strategy:
       matrix:
         version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
+        type: [oss, enterprise]
     permissions:
       id-token: write
       contents: read
@@ -22,6 +23,13 @@ jobs:
           repository: grafana/grafana
           ref: ${{ matrix.version }}
           path: grafana
+      - name: Checkout grafana-enterprise
+        if: matrix.type == 'enterprise'
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/grafana-enterprise
+          ref: ${{ matrix.version }}
+          path: grafana-enterprise
       - name: Clean runner
         run: |
           df -h
@@ -40,7 +48,15 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
           df -h
-      - uses: dagger/dagger-for-github@v6
+      - name: OSS tests
+        uses: dagger/dagger-for-github@v6
+        if: matrix.type == 'oss'
         with:
           verb: run
           args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana
+      - name: Enterprise tests
+        uses: dagger/dagger-for-github@v6
+        if: matrix.type == 'enterprise'
+        with:
+          verb: run
+          args: go run ./cmd artifacts -a targz:grafana-enterprise:linux/amd64 --grafana-dir=grafana --enterprise-dir=grafana-enterprise

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,3 +34,23 @@ jobs:
           go-version: stable
           cache: true
       - run: "go test ./... -v"
+  grafana-integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout grafana
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/grafana
+          ref: ${{ matrix.version }}
+          path: grafana-oss
+      - uses: dagger/dagger-for-github@v6
+        with:
+          verb: run
+          args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana-oss

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,23 +34,3 @@ jobs:
           go-version: stable
           cache: true
       - run: "go test ./... -v"
-  grafana-integration-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Checkout grafana
-        uses: actions/checkout@v4
-        with:
-          repository: grafana/grafana
-          ref: ${{ matrix.version }}
-          path: grafana-oss
-      - uses: dagger/dagger-for-github@v6
-        with:
-          verb: run
-          args: go run ./cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir=grafana-oss

--- a/arguments/golang.go
+++ b/arguments/golang.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	DefaultGoVersion      = "1.23.0"
+	DefaultGoVersion      = "1.23.1"
 	DefaultViceroyVersion = "v0.4.0"
 )
 


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**.

* [ ] I have tested this against `main` in Grafana.
* [ ] I have tested this against `main` in Grafana Enterprise.
* [ ] I have tested this against all active version branches of Grafana (v10.0.x, v10.1.x, v10.2.x, etc).
* [ ] I have tested this against all active version branches of Grafana Enterprise (v10.0.x, v10.1.x, v10.2.x, etc).
