### PR TITLE
Chore: Add head ref to pr-integration-tests

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -19,6 +19,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Checkout grafana
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`head_ref` is needed to make sure that the action runs against the PR branch