### PR TITLE
Chore: Remove extra checkout from pr-integration-tests

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -18,10 +18,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
       - name: Checkout grafana
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,13 +1,14 @@
 name: PR Integration Tests
 
 on:
+  workflow_dispatch: {}
   issue_comment:
     types: [created]
 
 jobs:
   grafana-integration-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/grafana-integration-tests' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/grafana-integration-tests')) }}
     strategy:
       matrix:
         version: [main, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x]


### PR DESCRIPTION
i'm attempting to get the comment action to report its status in the PR:

<img width="982" alt="image" src="https://github.com/user-attachments/assets/b9b11dec-8c2b-434f-b0a4-beb54dbff9f4">


https://github.com/grafana/grafana-build/pull/368 didn't work. i looked at ephemeral instances, and it seems like the config does not have the additional checkout step

# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**. To
run integration tests, add a comment to this PR with the following:

```
/grafana-integration-tests
```

* [ ] I have added the `/grafana-integration-tests` comment to this PR
* [ ] All integration tests have passed

