### PR TITLE
Remove sysvinit files from rpm packages

### DIFF
--- a/artifacts/package_rpm.go
+++ b/artifacts/package_rpm.go
@@ -92,7 +92,6 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 		NameOverride: d.NameOverride,
 		ConfigFiles: [][]string{
 			{"/src/packaging/rpm/sysconfig/grafana-server", "/pkg/etc/sysconfig/grafana-server"},
-			{"/src/packaging/rpm/init.d/grafana-server", "/pkg/etc/rc.d/init.d/grafana-server"},
 			{"/src/packaging/rpm/systemd/grafana-server.service", "/pkg/usr/lib/systemd/system/grafana-server.service"},
 		},
 		AfterInstall: "/src/packaging/rpm/control/postinst",

--- a/fpm/build.go
+++ b/fpm/build.go
@@ -113,6 +113,12 @@ func Build(builder *dagger.Container, opts BuildOpts, targz *dagger.File) *dagge
 		}
 	)
 
+	// init.d scripts are service management scripts that start/stop/restart/enable the grafana service without systemd.
+	// these are likely to be deprecated as systemd is now the default pretty much everywhere.
+	if opts.PackageType != PackageTypeRPM {
+		packagePaths = append(packagePaths, "/pkg/etc/init.d")
+	}
+
 	container := builder.
 		WithFile("/src/grafana.tar.gz", targz).
 		WithEnvVariable("XZ_DEFAULTS", "-T0").

--- a/fpm/build.go
+++ b/fpm/build.go
@@ -113,14 +113,6 @@ func Build(builder *dagger.Container, opts BuildOpts, targz *dagger.File) *dagge
 		}
 	)
 
-	// init.d scripts are service management scripts that start/stop/restart/enable the grafana service without systemd.
-	// these are likely to be deprecated as systemd is now the default pretty much everywhere.
-	if opts.PackageType == PackageTypeRPM {
-		packagePaths = append(packagePaths, "/pkg/etc/rc.d/init.d")
-	} else {
-		packagePaths = append(packagePaths, "/pkg/etc/init.d")
-	}
-
 	container := builder.
 		WithFile("/src/grafana.tar.gz", targz).
 		WithEnvVariable("XZ_DEFAULTS", "-T0").

--- a/frontend/npm.go
+++ b/frontend/npm.go
@@ -13,8 +13,7 @@ func NPMPackages(builder *dagger.Container, src *dagger.Directory, ersion string
 	return builder.WithExec([]string{"mkdir", "npm-packages"}).
 		WithEnvVariable("SHELL", "/bin/bash").
 		WithExec([]string{"yarn", "install", "--immutable"}).
-		WithExec([]string{"yarn", "run", "packages:build"}).
-		WithExec([]string{"/bin/bash", "-c", fmt.Sprintf("yarn run lerna version %s --exact --no-git-tag-version --no-push --force-publish -y && yarn lerna exec --no-private -- yarn pack --out /src/npm-packages/%%s-%v.tgz", ersion, "v"+ersion)}).
+		WithExec([]string{"/bin/bash", "-c", fmt.Sprintf("yarn run packages:build && yarn run lerna version %s --exact --no-git-tag-version --no-push --force-publish -y && yarn lerna exec --no-private -- yarn pack --out /src/npm-packages/%%s-%v.tgz", ersion, "v"+ersion)}).
 		Directory("./npm-packages")
 }
 


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**. To
run integration tests, add a comment to this PR with the following:

```
/grafana-integration-tests
```

* [x] I have ran the integraiton tests `gh workflow run --ref=${THIS_BRANCH} --repo=grafana/grafana-build pr-integration-tests.yml`
* [x] All integration tests have passed

