### PR TITLE
Make bundled plugins optional

### DIFF
--- a/frontend/build.go
+++ b/frontend/build.go
@@ -16,7 +16,7 @@ func Build(builder *dagger.Container) *dagger.Directory {
 func BuildPlugins(builder *dagger.Container) *dagger.Directory {
 	public := builder.
 		WithExec([]string{"yarn", "install", "--immutable"}).
-		WithExec([]string{"yarn", "run", "plugins:build-bundled"}).
+		WithExec([]string{"/bin/sh", "-c", `if [ -d /src/plugins-bundled ]; then yarn run plugins:build-bundled; else mkdir /src/plugins-bundled; fi`}).
 		WithExec([]string{"/bin/sh", "-c", "find /src/plugins-bundled -type d -name node_modules -print0 | xargs -0 rm -rf"}).
 		Directory("/src/plugins-bundled")
 


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**. To
run integration tests, add a comment to this PR with the following:

```
/grafana-integration-tests
```

* [x] I have ran the integraiton tests `gh workflow run --ref=${THIS_BRANCH} --repo=grafana/grafana-build pr-integration-tests.yml`
* [x] All integration tests have passed

# Context
https://github.com/grafana/grafana/pull/96490

# Testing

Have manually tested this locally with the [branch to remove bundled plugins from Grafana](https://github.com/grafana/grafana/pull/96490) and 10.4.x (the last known supported Grafana version that also supports bundled plugins)

