### PR TITLE
adds timetzdata tag to build to fix issue

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -41,7 +41,6 @@ enable = [
   "ineffassign",
   "misspell",
   "nakedret",
-  "exportloopref",
   "staticcheck",
   "stylecheck",
   "typecheck",

--- a/flags/packages.go
+++ b/flags/packages.go
@@ -7,6 +7,7 @@ import (
 
 var DefaultTags = []string{
 	"osusergo",
+	"timetzdata",
 }
 
 const (


### PR DESCRIPTION
# Requirements

The `main` branch of `grafana-build` should be compatible with all active versions of Grafana **and Grafana-Enterprise**. To
run integration tests, add a comment to this PR with the following:

```
/grafana-integration-tests
```

* [ ] I have ran the integraiton tests `gh workflow run --ref=${THIS_BRANCH} --repo=grafana/grafana-build pr-integration-tests.yml`
* [ ] All integration tests have passed

