### PR TITLE
Packages: add 'enterprise' build tag to go build for Enterprise and BoringCrypto builds

### DIFF
--- a/flags/packages.go
+++ b/flags/packages.go
@@ -47,7 +47,7 @@ var PackageNameFlags = []pipeline.Flag{
 			Enterprise:         true,
 			WireTag:            "enterprise",
 			GoExperiments:      []string{},
-			GoTags:             DefaultTags,
+			GoTags:             append(DefaultTags, "enterprise"),
 		},
 	},
 	{
@@ -69,7 +69,7 @@ var PackageNameFlags = []pipeline.Flag{
 			Enterprise:         true,
 			WireTag:            "enterprise",
 			GoExperiments:      []string{"boringcrypto"},
-			GoTags:             DefaultTags,
+			GoTags:             append(DefaultTags, "enterprise"),
 		},
 	},
 }


### PR DESCRIPTION
From the Spanner work https://github.com/grafana/grafana/pull/101398, we've added a `//go:build enterprise || pro` to some files in the OSS repo, but they are not being included in the Enterprise builds, so we need to pass an `enterprise` Go build tag for these editions: Enterprise and Enterprise+BoringCrypto.