### PR TITLE
Add s390x support

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -99,7 +99,9 @@ func GolangContainer(
 		// Install the toolchain specifically for armv7 until we figure out why it's crashing w/ zig container = container.
 		WithExec([]string{"mkdir", "/toolchain"}).
 		WithExec([]string{"wget", "http://musl.cc/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
-		WithExec([]string{"tar", "-xvf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"})
+		WithExec([]string{"tar", "-xvf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
+		WithExec([]string{"wget", "https://musl.cc/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
+		WithExec([]string{"tar", "-xvf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"})
 
 	return WithGoEnv(log, container, distro, opts)
 }

--- a/backend/distributions.go
+++ b/backend/distributions.go
@@ -248,6 +248,22 @@ func BuildOptsStaticARM(distro Distribution, experiments []string, tags []string
 	}
 }
 
+// BuildOptsStaticS390X builds Grafana statically for the s390x arch
+func BuildOptsStaticS390X(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
+	var (
+		os, _ = OSAndArch(distro)
+	)
+
+	return &GoBuildOpts{
+		CC:                "/toolchain/s390x-linux-musl-cross/bin/s390x-linux-musl-gcc",
+		CXX:               "/toolchain/s390x-linux-musl-cross/bin/s390x-linux-musl-cpp",
+		ExperimentalFlags: experiments,
+		OS:                os,
+		Arch:              "s390x",
+		CGOEnabled:        true,
+	}
+}
+
 func StdZigBuildOpts(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
 	var (
 		os, arch = OSAndArch(distro)
@@ -309,6 +325,7 @@ var DistributionGoOpts = map[Distribution]DistroBuildOptsFunc{
 	DistLinuxARM:          BuildOptsStaticARM,
 	DistLinuxARMv6:        BuildOptsStaticARM,
 	DistLinuxARMv7:        BuildOptsStaticARM,
+	DistLinuxS390X:        BuildOptsStaticS390X,
 	DistLinuxARM64:        StdZigBuildOpts,
 	DistLinuxARM64Dynamic: StdZigBuildOpts,
 	DistLinuxAMD64:        StdZigBuildOpts,

--- a/flags/distro.go
+++ b/flags/distro.go
@@ -14,6 +14,7 @@ var StaticDistributions = []backend.Distribution{
 	backend.DistLinuxARM64,
 	backend.DistLinuxARMv7,
 	backend.DistLinuxRISCV64,
+	backend.DistLinuxS390X,
 }
 
 var DynamicDistributions = []backend.Distribution{


### PR DESCRIPTION
Adds support for building Grafana for the `linux/s390x` target.

# Requirements

* [x] I have ran the integraiton tests
* [x] All integration tests have passed