### PR TITLE
Chore: Add .citools as optional directory

### DIFF
--- a/backend/builder.go
+++ b/backend/builder.go
@@ -196,11 +196,15 @@ func Wire(d *dagger.Client, log *slog.Logger, src *dagger.Directory, platform da
 			return nil
 		}
 
+		log.Info(path)
 		if strings.HasSuffix(info.Name(), ".citools") {
 			citoolsDir = path
 		}
 		return nil
 	})
+
+	log.Info("@@@@@")
+	log.Info("Citools dir: ", citoolsDir)
 	if citoolsDir != "" {
 		log.Info("Detected .citools directory, including into the build.")
 		// .citools contain refs to executable dependencies

--- a/backend/builder.go
+++ b/backend/builder.go
@@ -183,7 +183,7 @@ func Wire(d *dagger.Client, log *slog.Logger, src *dagger.Directory, platform da
 	// withCue is only required during `make gen-go` in 9.5.x or older.
 	builder := withCue(golang.Container(d, platform, goVersion), src)
 
-	if _, err := os.Stat(".citools"); err == nil {
+	if _, err := os.Stat("./.citools"); err == nil {
 		log.Info("Detected .citools directory, including into the build.")
 		// .citools contain refs to executable dependencies
 		builder = builder.WithDirectory("/src/.citools", src.Directory(".citools"))

--- a/backend/builder.go
+++ b/backend/builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana-build/golang"
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 // BuildOpts are general options that can change the way Grafana is compiled regardless of distribution.
@@ -189,6 +190,22 @@ func Wire(d *dagger.Client, log *slog.Logger, src *dagger.Directory, platform da
 	} else {
 		log.Info(".citools directory not detected.")
 	}
+
+	log.Info("@@@@@@@@@@@@@@@@@@@")
+	filepath.Walk("./", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			return nil
+		}
+
+		log.Info(path)
+		return nil
+	})
+
+	log.Info("@@@@@@@@@@@@@@@@@@@")
 
 	return builder.WithExec([]string{"apk", "add", "make"}).
 		WithDirectory("/src/", src, dagger.ContainerWithDirectoryOpts{

--- a/backend/builder.go
+++ b/backend/builder.go
@@ -1,13 +1,12 @@
 package backend
 
 import (
+	"dagger.io/dagger"
 	"errors"
 	"fmt"
-	"log/slog"
-
-	"dagger.io/dagger"
 	"github.com/grafana/grafana-build/containers"
 	"github.com/grafana/grafana-build/golang"
+	"log/slog"
 )
 
 // BuildOpts are general options that can change the way Grafana is compiled regardless of distribution.
@@ -155,7 +154,6 @@ func Builder(
 		WithEnvVariable("GOCACHE", "/root/.cache/go")
 
 	commitInfo := GetVCSInfo(src, version, opts.Enterprise)
-
 	builder = withCue(builder, src).
 		WithDirectory("/src/", src, dagger.ContainerWithDirectoryOpts{
 			Include: []string{"**/*.mod", "**/*.sum", "**/*.work"},
@@ -189,6 +187,7 @@ func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goV
 		WithDirectory("/src/pkg", src.Directory("pkg")).
 		WithDirectory("/src/apps", src.Directory("apps")).
 		WithDirectory("/src/.bingo", src.Directory(".bingo")).
+		WithDirectory("/src/.citools", src.Directory(".citools")).
 		WithFile("/src/Makefile", src.File("Makefile")).
 		WithWorkdir("/src").
 		WithExec([]string{"make", "gen-go", fmt.Sprintf("WIRE_TAGS=%s", wireTag)}).


### PR DESCRIPTION
## Requirements
After agreeing that we do not do golang upgrades in release branches we have a small inconsistency in build setup between main and release branches: main uses .citools directory for tools while release branches still use .bingo

This PR adds conditional addition of .citools directory to the drone container.

## ci runs:

### Release branch
https://github.com/grafana/grafana/actions/runs/15132323453/job/42535994820

### Main branch
https://github.com/grafana/grafana/actions/runs/15131925762/job/42534703701

* [ ] I have ran the integraiton tests `gh workflow run --ref=${THIS_BRANCH} --repo=grafana/grafana-build pr-integration-tests.yml`
* [ ] All integration tests have passed

